### PR TITLE
Allow vagrant install to run powershell scripts

### DIFF
--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -88,6 +88,9 @@ class VagrantInstall extends InstallableItem {
               .execFile(
                 'powershell',
                 [
+                  '-ExecutionPolicy',
+                  'ByPass',
+                  '-File',
                   this.vagrantPathScript
                 ],
                 (error, stdout, stderr) => {


### PR DESCRIPTION
Apparently some windows versions don't allow powershell scripts to be run by default. This should allow the vagrant installation to bypass that.