### PR TITLE
Refactor CDK install using promises and shared install helper

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -127,19 +127,18 @@ class CDKInstall extends InstallableItem {
   }
 
   setupVagrant(installer, result) {
-    let self = this;
-    return new Promise(function (resolve, reject) {
-      let vagrantInstall = self.installerDataSvc.getInstallable(VagrantInstall.key());
+    return new Promise((resolve, reject) => {
+      let vagrantInstall = this.installerDataSvc.getInstallable(VagrantInstall.key());
 
       if (vagrantInstall !== undefined && vagrantInstall.isInstalled()) {
-        return self.postVagrantSetup(installer, result)
+        return this.postVagrantSetup(installer, result)
         .then((res) => { return resolve(res); })
         .catch((err) => { return reject(err); });
       } else {
         Logger.info(CDKInstall.key() + ' - Vagrant has not finished installing, listener created to be called when it has.');
         ipcRenderer.on('installComplete', (event, arg) => {
           if (arg == 'vagrant') {
-            return self.postVagrantSetup(installer, result)
+            return this.postVagrantSetup(installer, result)
             .then((res) => { return resolve(res); })
             .catch((err) => { return reject(err); });
           }

--- a/browser/model/helpers/installer.js
+++ b/browser/model/helpers/installer.js
@@ -16,19 +16,18 @@ class Installer {
   }
 
   exec(command, options, result) {
-    let self = this;
-    return new Promise(function (resolve, reject) {
-      Logger.info(self.key + ' - Execute ' + command);
-      child_process.exec(command, options, function(error, stdout, stderr) {
+    return new Promise((resolve, reject) => {
+      Logger.info(this.key + ' - Execute ' + command);
+      child_process.exec(command, options, (error, stdout, stderr) => {
         if (error && error !== '') {
-          Logger.error(self.key + ' - ' + error);
-          Logger.error(self.key + ' - ' + stderr);
+          Logger.error(this.key + ' - ' + error);
+          Logger.error(this.key + ' - ' + stderr);
           reject(error);
         } else {
           if (stdout && stdout != '') {
-            Logger.info(self.key + ' - ' + stdout);
+            Logger.info(this.key + ' - ' + stdout);
           }
-          Logger.info(self.key + ' - Execute ' + command + ' SUCCESS');
+          Logger.info(this.key + ' - Execute ' + command + ' SUCCESS');
           resolve(true);
         }
       });
@@ -36,19 +35,18 @@ class Installer {
   }
 
   execFile(file, args, result) {
-    let self = this;
-    return new Promise(function(resolve, reject) {
-      Logger.info(self.key + ' - Execute ' + file + ' ' + args);
-      child_process.execFile(file, args, function(error, stdout, stderr) {
+    return new Promise((resolve, reject) => {
+      Logger.info(this.key + ' - Execute ' + file + ' ' + args);
+      child_process.execFile(file, args, (error, stdout, stderr) => {
         if (error && error !== '') {
-          Logger.error(self.key + ' - ' + error);
-          Logger.error(self.key + ' - ' + stderr);
+          Logger.error(this.key + ' - ' + error);
+          Logger.error(this.key + ' - ' + stderr);
           reject(error);
         } else {
           if (stdout && stdout != '') {
-            Logger.info(self.key + ' - ' + stdout);
+            Logger.info(this.key + ' - ' + stdout);
           }
-          Logger.info(self.key + ' - Execute ' + file + ' ' + args + ' SUCCESS');
+          Logger.info(this.key + ' - Execute ' + file + ' ' + args + ' SUCCESS');
           resolve(true);
         }
       });
@@ -56,32 +54,30 @@ class Installer {
   }
 
   unzip(zipFile, extractTo, result) {
-    let self = this;
-    return new Promise(function (resolve, reject) {
-      Logger.info(self.key + ' - Extract ' + zipFile + ' to ' + extractTo);
+    return new Promise((resolve, reject) => {
+      Logger.info(this.key + ' - Extract ' + zipFile + ' to ' + extractTo);
       fs.createReadStream(zipFile)
       .pipe(unzip.Extract({path: extractTo}))
       .on('close', () => {
-        Logger.info(self.key + ' - Extract ' + zipFile + ' to ' + extractTo + ' SUCCESS');
+        Logger.info(this.key + ' - Extract ' + zipFile + ' to ' + extractTo + ' SUCCESS');
         resolve(true);
       })
       .on('error', (err) => {
-        Logger.error(self.key + ' - ' + err);
+        Logger.error(this.key + ' - ' + err);
         reject(err);
       });
     });
   }
 
   moveFile(source, target, result) {
-    let self = this;
-    return new Promise(function (resolve, reject) {
-      Logger.info(self.key + ' - Move ' + source + ' to ' + target);
+    return new Promise((resolve, reject) => {
+      Logger.info(this.key + ' - Move ' + source + ' to ' + target);
       fs.move(source, target, (err) => {
         if (err) {
-          Logger.error(self.key + ' - ' + err);
+          Logger.error(this.key + ' - ' + err);
           reject(err);
         } else {
-          Logger.info(self.key + ' - Move ' + source + ' to ' + target + ' SUCCESS');
+          Logger.info(this.key + ' - Move ' + source + ' to ' + target + ' SUCCESS');
           resolve(true);
         }
       });
@@ -89,15 +85,14 @@ class Installer {
   }
 
   writeFile(file, data, result) {
-    let self = this;
-    return new Promise(function (resolve, reject) {
-      Logger.info(self.key + ' - Write ' + file);
-      fs.writeFile(file, data, function (err) {
+    return new Promise((resolve, reject) => {
+      Logger.info(this.key + ' - Write ' + file);
+      fs.writeFile(file, data, (err) => {
         if (err) {
-          Logger.error(self.key + ' - ' + err);
+          Logger.error(this.key + ' - ' + err);
           reject(err);
         } else {
-          Logger.info(self.key + ' - Write ' + file + ' SUCCESS');
+          Logger.info(this.key + ' - Write ' + file + ' SUCCESS');
           resolve(true);
         }
       });

--- a/browser/model/helpers/installer.js
+++ b/browser/model/helpers/installer.js
@@ -1,0 +1,120 @@
+'use strict';
+
+let fs = require('fs-extra');
+let child_process = require('child_process');
+let unzip = require('unzip');
+
+import Logger from '../../services/logger';
+
+class Installer {
+
+  constructor(key, progress, success, failure) {
+    this.progress = progress;
+    this.success = success;
+    this.failure = failure;
+    this.key = key;
+  }
+
+  exec(command, options, result) {
+    let self = this;
+    return new Promise(function (resolve, reject) {
+      Logger.info(self.key + ' - Execute ' + command);
+      child_process.exec(command, options, function(error, stdout, stderr) {
+        if (error && error !== '') {
+          Logger.error(self.key + ' - ' + error);
+          Logger.error(self.key + ' - ' + stderr);
+          reject(error);
+        } else {
+          if (stdout && stdout != '') {
+            Logger.info(self.key + ' - ' + stdout);
+          }
+          Logger.info(self.key + ' - Execute ' + command + ' SUCCESS');
+          resolve(true);
+        }
+      });
+    });
+  }
+
+  execFile(file, args, result) {
+    let self = this;
+    return new Promise(function(resolve, reject) {
+      Logger.info(self.key + ' - Execute ' + file + ' ' + args);
+      child_process.execFile(file, args, function(error, stdout, stderr) {
+        if (error && error !== '') {
+          Logger.error(self.key + ' - ' + error);
+          Logger.error(self.key + ' - ' + stderr);
+          reject(error);
+        } else {
+          if (stdout && stdout != '') {
+            Logger.info(self.key + ' - ' + stdout);
+          }
+          Logger.info(self.key + ' - Execute ' + file + ' ' + args + ' SUCCESS');
+          resolve(true);
+        }
+      });
+    });
+  }
+
+  unzip(zipFile, extractTo, result) {
+    let self = this;
+    return new Promise(function (resolve, reject) {
+      Logger.info(self.key + ' - Extract ' + zipFile + ' to ' + extractTo);
+      fs.createReadStream(zipFile)
+      .pipe(unzip.Extract({path: extractTo}))
+      .on('close', () => {
+        Logger.info(self.key + ' - Extract ' + zipFile + ' to ' + extractTo + ' SUCCESS');
+        resolve(true);
+      })
+      .on('error', (err) => {
+        Logger.error(self.key + ' - ' + err);
+        reject(err);
+      });
+    });
+  }
+
+  moveFile(source, target, result) {
+    let self = this;
+    return new Promise(function (resolve, reject) {
+      Logger.info(self.key + ' - Move ' + source + ' to ' + target);
+      fs.move(source, target, (err) => {
+        if (err) {
+          Logger.error(self.key + ' - ' + err);
+          reject(err);
+        } else {
+          Logger.info(self.key + ' - Move ' + source + ' to ' + target + ' SUCCESS');
+          resolve(true);
+        }
+      });
+    });
+  }
+
+  writeFile(file, data, result) {
+    let self = this;
+    return new Promise(function (resolve, reject) {
+      Logger.info(self.key + ' - Write ' + file);
+      fs.writeFile(file, data, function (err) {
+        if (err) {
+          Logger.error(self.key + ' - ' + err);
+          reject(err);
+        } else {
+          Logger.info(self.key + ' - Write ' + file + ' SUCCESS');
+          resolve(true);
+        }
+      });
+    });
+  }
+
+  succeed(done) {
+    if (done) {
+      this.progress.setComplete();
+      this.success();
+    }
+  }
+
+  fail(error) {
+    return this.failure(error);
+  }
+
+}
+
+export default Installer;

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -1,0 +1,265 @@
+'use strict';
+
+import chai, { expect } from 'chai';
+import { default as sinonChai } from 'sinon-chai';
+import mockfs from 'mock-fs';
+import request from 'request';
+import fs from 'fs-extra';
+import path from 'path';
+import CDKInstall from 'model/cdk';
+import Logger from 'services/logger';
+import Downloader from 'model/helpers/downloader';
+import Installer from 'model/helpers/installer';
+chai.use(sinonChai);
+
+let sinon  = require('sinon');
+require('sinon-as-promised');
+
+describe('CDK installer', function() {
+  let sandbox, fakeProgress, DataStub, installerDataSvc;
+  let infoStub, errorStub;
+  let fakeData = {
+    tempDir: function() { return 'temp'; },
+    installDir: function() { return 'install'; },
+    getUsername: function() { return 'user'; },
+    getPassword: function() { return 'password'; },
+    ocDir: function() {},
+    vagrantDir: function() {},
+    cdkVagrantfileDir: function() {},
+    cdkBoxDir: function() {},
+    cdkMarker: function() {},
+    cdkDir: function() {},
+    getInstallable: function(key) {}
+  };
+
+  installerDataSvc = sinon.stub(fakeData);
+  installerDataSvc.tempDir.returns('temp');
+  installerDataSvc.installDir.returns('install');
+  installerDataSvc.getUsername.returns('user');
+  installerDataSvc.getPassword.returns('password');
+  installerDataSvc.cdkDir.returns(path.join(installerDataSvc.installDir(), 'cdk'));
+  installerDataSvc.ocDir.returns(path.join(installerDataSvc.cdkDir(), 'bin'));
+  installerDataSvc.vagrantDir.returns(path.join(installerDataSvc.installDir(), 'vagrant'));
+  installerDataSvc.cdkVagrantfileDir.returns(path.join(installerDataSvc.cdkDir(), 'openshift-vagrant'));
+  installerDataSvc.cdkBoxDir.returns(path.join(installerDataSvc.cdkDir(), 'boxes'));
+  installerDataSvc.cdkMarker.returns(path.join(installerDataSvc.cdkVagrantfileDir(), '.cdk'));
+
+  before(function() {
+    infoStub = sinon.stub(Logger, 'info');
+    errorStub = sinon.stub(Logger, 'error');
+
+    fakeProgress = {
+      setStatus: function (desc) { return; },
+      setCurrent: function (val) {},
+      setLabel: function (label) {},
+      setComplete: function() {},
+      setTotalDownloadSize: function(size) {},
+      downloaded: function(amt, time) {}
+    };
+
+    mockfs({
+      'temp': {
+      },
+      'install': {
+      }
+    });
+  });
+
+  after(function() {
+    infoStub.restore();
+    errorStub.restore();
+    mockfs.restore();
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('should not download cdk when an installation exists', function() {
+    let cdk = new CDKInstall(installerDataSvc, 900, 'cdkUrl', 'cdkBoxUrl', 'ocUrl', 'vagrantFileUrl', 'pscpUrl', 'installFile');
+    expect(cdk.useDownload).to.be.false;
+  });
+
+  it('should fail when some download url is not set and installed file not defined', function() {
+    expect(function() {
+      new CDKInstall(installerDataSvc, 900, null, 'ocUrl', 'vagrantFileUrl', 'pscpUrl', null);
+    }).to.throw('No download URL set');
+  });
+
+  it('should fail when no url is set and installed file is empty', function() {
+    expect(function() {
+      new CDKInstall(installerDataSvc, 900, null, 'ocUrl', 'vagrantFileUrl', 'pscpUrl', '');
+    }).to.throw('No download URL set');
+  });
+
+  it('should download files when no installation is found', function() {
+    expect(new CDKInstall(installerDataSvc, 900, 'cdkUrl', 'cdkBoxUrl', 'ocUrl', 'vagrantFileUrl', 'pscpUrl', null).useDownload).to.be.true;
+  });
+
+  let cdkUrl = 'https://developers.redhat.com/download-manager/jdf/file/cdk-2.0.0-beta3.zip?workflow=direct',
+      cdkBoxUrl ='http://cdk-builds.usersys.redhat.com/builds/11-Dec-2015/rhel-7.2-server-kubernetes-vagrant-scratch-7.2-1.x86_64.vagrant-virtualbox.box',
+      ocUrl = 'https://ci.openshift.redhat.com/jenkins/job/devenv_ami/3072/artifact/origin/artifacts/release/openshift-origin-client-tools-v1.1-658-g273458a-273458a-windows.zip',
+      vagrantFileUrl = 'https://github.com/redhat-developer-tooling/openshift-vagrant/archive/master.zip',
+      pscpUrl = 'http://the.earth.li/~sgtatham/putty/latest/x86/pscp.exe';
+
+  let boxName = 'rhel-cdk-kubernetes-7.2-6.x86_64.vagrant-virtualbox.box';
+  let cdkDownloadedFile = path.join(installerDataSvc.tempDir(), 'cdk.zip'),
+      cdkBoxDownloadedFile = path.join(installerDataSvc.tempDir(), boxName),
+      ocDownloadedFile = path.join(installerDataSvc.tempDir(), 'oc.zip'),
+      vagrantDownloadedFile = path.join(installerDataSvc.tempDir(), 'vagrantfile.zip'),
+      pscpDownloadedFile = path.join(installerDataSvc.tempDir(), 'pscp.exe'),
+      pscpPathScript = path.join(installerDataSvc.tempDir(), 'set-pscp-path.ps1');
+
+  describe('when downloading the cdk tools', function() {
+
+    it('should set progress to "Downloading"', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let spy = sandbox.spy(fakeProgress, 'setStatus');
+
+      installer.downloadInstaller(fakeProgress, function() {}, function() {});
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith('Downloading');
+    });
+
+    it('should write the data into temp folder', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let streamSpy = sandbox.spy(Downloader.prototype, 'setWriteStream');
+      let fsSpy = sandbox.spy(fs, 'createWriteStream');
+
+      installer.downloadInstaller(fakeProgress, function() {}, function() {});
+
+      //expect 5 streams to be set and created
+      expect(streamSpy.callCount).to.equal(5);
+      expect(fsSpy.callCount).to.equal(5);
+      expect(fsSpy).calledWith(cdkDownloadedFile);
+      expect(fsSpy).calledWith(cdkBoxDownloadedFile);
+      expect(fsSpy).calledWith(ocDownloadedFile);
+      expect(fsSpy).calledWith(vagrantDownloadedFile);
+      expect(fsSpy).calledWith(pscpDownloadedFile);
+    });
+
+    it('should call a correct downloader request for each file', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let spy = sandbox.spy(Downloader.prototype, 'download');
+      let spyAuth = sandbox.spy(Downloader.prototype, 'downloadAuth');
+
+      let headers = {
+        url: cdkUrl,
+        rejectUnauthorized: false
+      };
+
+      installer.downloadInstaller(fakeProgress, function() {}, function() {});
+
+      //we download 1 out of 5 files with authentication
+      expect(spy.callCount).to.equal(4);
+      expect(spyAuth).to.have.been.calledOnce;
+
+      expect(spy).calledWith(cdkBoxUrl);
+      expect(spy).calledWith(ocUrl);
+      expect(spy).calledWith(vagrantFileUrl);
+      expect(spy).calledWith(pscpUrl);
+
+      expect(spyAuth).calledWith(headers, installerDataSvc.getUsername(), installerDataSvc.getPassword());
+    });
+
+    it('should fail with an invalid url', function(done) {
+      let url = 'url';
+      function failsWithInvalidUrl() {
+        let installer = new CDKInstall(installerDataSvc, 900, url, url, url, url, url, null);
+        installer.downloadInstaller(fakeProgress,
+          function() {}, function() {});
+        }
+        expect(failsWithInvalidUrl).to.throw('Invalid URI "' + url + '"');
+        done();
+    });
+  });
+
+  describe('when installing cdk', function() {
+    it('should set progress to "Installing"', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let spy = sandbox.spy(fakeProgress, 'setStatus');
+
+      installer.install(fakeProgress, null, null);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith('Installing');
+    });
+
+    it('should extract cdk archive to install folder', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+
+      let spy = sandbox.spy(Installer.prototype, 'unzip');
+      installer.install(fakeProgress, function() {}, function (err) {});
+
+      expect(spy).to.have.been.called;
+      expect(spy).calledWith(cdkDownloadedFile, installerDataSvc.installDir());
+    });
+
+    it('createEnvironment should return path to vagrant/bin', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let env = installer.createEnvironment();
+
+      expect(env['path']).equal(path.join(installerDataSvc.vagrantDir(), 'bin') + ';');
+    });
+
+    it('setupVagrant should wait for vagrant install to complete', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let spy = sandbox.spy(installer, 'postVagrantSetup');
+
+      installer.setupVagrant();
+      expect(spy).not.called;
+    });
+
+    it('setupVagrant should call postVagrantSetup if vagrant is installed', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let spy = sandbox.spy(installer, 'postVagrantSetup');
+
+      let fakeInstall = {
+        isInstalled: function() { return true; }
+      };
+      installerDataSvc.getInstallable.returns(fakeInstall);
+
+      installer.setupVagrant();
+      expect(spy).calledOnce;
+    });
+
+    it('postVagrantSetup should not execute if vagrant installation does not exist', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let helper = new Installer('cdk', fakeProgress, function() {}, function (err) {});
+      let spy = sandbox.spy(Installer.prototype, 'exec');
+      let envSpy = sandbox.spy(installer, 'createEnvironment');
+
+      let fakeInstall = {
+        isInstalled: function() { return false; }
+      };
+      installerDataSvc.getInstallable.returns(fakeInstall);
+
+      installer.setupVagrant(helper);
+      expect(envSpy).not.called;
+      expect(spy).not.called;
+    });
+
+    it('postVagrantSetup should execute when vagrant installation is complete', function() {
+      let installer = new CDKInstall(installerDataSvc, 900, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, null);
+      let helper = new Installer('cdk', fakeProgress, function() {}, function (err) {});
+      let spy = sandbox.spy(installer, 'createEnvironment');
+      let execStub = sandbox.stub(helper, 'exec');
+      execStub.resolves(true);
+
+      let fakeInstall = {
+        isInstalled: function() { return true; }
+      };
+      installerDataSvc.getInstallable.returns(fakeInstall);
+
+      installer.setupVagrant(helper);
+
+      expect(spy).calledOnce;
+      expect(execStub).called;
+    });
+  });
+});

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -16,11 +16,11 @@ let sinon  = require('sinon');
 require('sinon-as-promised');
 
 describe('CDK installer', function() {
-  let sandbox, fakeProgress, DataStub, installerDataSvc;
+  let sandbox, DataStub, installerDataSvc;
   let infoStub, errorStub;
   let fakeData = {
-    tempDir: function() { return 'temp'; },
-    installDir: function() { return 'install'; },
+    tempDir: function() { return 'temporaryFolder'; },
+    installDir: function() { return 'installFolder'; },
     getUsername: function() { return 'user'; },
     getPassword: function() { return 'password'; },
     ocDir: function() {},
@@ -31,10 +31,18 @@ describe('CDK installer', function() {
     cdkDir: function() {},
     getInstallable: function(key) {}
   };
+  let fakeProgress = {
+    setStatus: function (desc) { return; },
+    setCurrent: function (val) {},
+    setLabel: function (label) {},
+    setComplete: function() {},
+    setTotalDownloadSize: function(size) {},
+    downloaded: function(amt, time) {}
+  };
 
   installerDataSvc = sinon.stub(fakeData);
-  installerDataSvc.tempDir.returns('temp');
-  installerDataSvc.installDir.returns('install');
+  installerDataSvc.tempDir.returns('temporaryFolder');
+  installerDataSvc.installDir.returns('installFolder');
   installerDataSvc.getUsername.returns('user');
   installerDataSvc.getPassword.returns('password');
   installerDataSvc.cdkDir.returns(path.join(installerDataSvc.installDir(), 'cdk'));
@@ -48,20 +56,12 @@ describe('CDK installer', function() {
     infoStub = sinon.stub(Logger, 'info');
     errorStub = sinon.stub(Logger, 'error');
 
-    fakeProgress = {
-      setStatus: function (desc) { return; },
-      setCurrent: function (val) {},
-      setLabel: function (label) {},
-      setComplete: function() {},
-      setTotalDownloadSize: function(size) {},
-      downloaded: function(amt, time) {}
-    };
-
     mockfs({
-      'temp': {
-      },
-      'install': {
-      }
+      temporaryFolder: {},
+      installFolder: {}
+    }, {
+      createCwd: false,
+      createTmp: false
     });
   });
 

--- a/test/unit/model/helpers/installer-test.js
+++ b/test/unit/model/helpers/installer-test.js
@@ -1,0 +1,291 @@
+'use strict';
+
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import { default as sinonChai } from 'sinon-chai';
+import Installer from 'model/helpers/installer';
+import mockfs from 'mock-fs';
+import path from 'path';
+import Logger from 'services/logger';
+chai.use(sinonChai);
+
+let fs = require('fs-extra');
+let child_process = require('child_process');
+let unzip = require('unzip');
+
+describe('Installer', function() {
+  let installer;
+  let sandbox;
+  let fakeProgress;
+  let infoStub, errorStub;
+
+  before(function() {
+    infoStub = sinon.stub(Logger, 'info');
+    errorStub = sinon.stub(Logger, 'error');
+
+    mockfs({
+      'temp': {
+        'script': 'file content here',
+        'zipFile.zip': 'content'
+      },
+      'install' : {}
+    });
+
+    fakeProgress = {
+      setStatus: function (desc) { return; },
+      setCurrent: function (val) {},
+      setLabel: function (label) {},
+      setComplete: function() {},
+      setTotalDownloadSize: function(size) {},
+      downloaded: function(amt, time) {}
+    };
+
+    installer = new Installer('test', fakeProgress, () => { return 'success'; }, (err) => { return err; });
+  });
+
+  after(function() {
+    infoStub.restore();
+    errorStub.restore();
+    mockfs.restore();
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  })
+
+  describe('exec', function() {
+    let command = 'command';
+    let args = ['arg1', 'arg2', 'arg3'];
+
+    it('should call child_process#exec with the correct parameters', function() {
+      let spy = sandbox.spy(child_process, 'exec');
+
+      installer.exec(command, args);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith(command, args);
+    });
+
+    it('should resolve as true if no error occurs' , function() {
+      sandbox.stub(child_process, 'exec').yields();
+
+      return installer.exec(command, args)
+      .then(function(result) {
+        expect(result).to.equal(true);
+      });
+    });
+
+    it('should reject when an error occurs', function() {
+      let err = new Error('fatal error');
+      let proc = sandbox.stub(child_process, 'exec');
+      proc.throws(err);
+
+      return installer.exec(command, args)
+      .then(function(result) {
+        expect.fail('it did not reject');
+      })
+      .catch(function(error) {
+        expect(error).to.equal(err);
+      });
+    });
+  });
+
+  describe('execFile', function() {
+    let file = path.join('temp', 'script');
+    let args = ['arg1', 'arg2', 'arg3'];
+
+    it('should call child_process#execFile with the correct parameters', function() {
+      let spy = sandbox.spy(child_process, 'execFile');
+
+      installer.execFile(file, args);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith(file, args);
+    });
+
+    it('should resolve as true if no error occurs' , function() {
+      sandbox.stub(child_process, 'execFile').yields();
+
+      return installer.execFile(file, args)
+      .then(function(result) {
+        expect(result).to.equal(true);
+      });
+    });
+
+    it('should reject when an error occurs', function() {
+      let err = new Error('fatal error');
+      let proc = sandbox.stub(child_process, 'execFile');
+      proc.throws(err);
+
+      return installer.execFile(file, args)
+      .then(function(result) {
+        expect.fail('it did not reject');
+      })
+      .catch(function(error) {
+        expect(error).to.equal(err);
+      });
+    });
+  });
+
+  describe('unzip', function() {
+    let file = path.join('temp', 'zipFile.zip');
+    let dir = 'install';
+
+    it('should read the specified file', function() {
+      let spy = sandbox.spy(fs, 'createReadStream');
+
+      installer.unzip(file, dir);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith(file);
+    });
+
+    it('should call unzip#Extract into a correct folder', function() {
+      let spy = sandbox.spy(unzip, 'Extract');
+
+      installer.unzip(file, dir);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith({ path: dir });
+    });
+
+    it('should fail with an invalid zip file', function() {
+      return installer.unzip(file, dir)
+      .then(function(result) {
+        expect.fail('it did not reject');
+      })
+      .catch(function(error) {
+        expect(error.message).to.contain('invalid signature');
+      });
+    });
+
+    it('should reject when an error occurs', function() {
+      let err = new Error('fatal error');
+      let proc = sandbox.stub(unzip, 'Extract');
+      proc.throws(err);
+
+      return installer.unzip(file, dir)
+      .then(function(result) {
+        expect.fail('it did not reject');
+      })
+      .catch(function(error) {
+        expect(error).to.equal(err);
+      });
+    });
+  });
+
+  describe('moveFile', function() {
+    let source = path.join('temp', 'zipFile.zip');
+    let target = path.join('install', 'target');
+
+    it('should call fs#move with correct arguments', function() {
+      let spy = sandbox.spy(fs, 'move');
+
+      installer.moveFile(source, target);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith(source, target);
+    });
+
+    it('should resolve as true when no error occurs', function() {
+      sandbox.stub(fs, 'move').yields();
+
+      return installer.moveFile(source, target)
+      .then(function(result) {
+        expect(result).to.equal(true);
+      });
+    });
+
+    it('should reject when an error occurs', function() {
+      let err = new Error('fatal error');
+      let proc = sandbox.stub(fs, 'move');
+      proc.throws(err);
+
+      return installer.moveFile(source, target)
+      .then(function(result) {
+        expect.fail('it did not reject');
+      })
+      .catch(function(error) {
+        expect(error).to.equal(err);
+      });
+    });
+
+    it('should fail with a non-existing source', function() {
+      return installer.moveFile(source, target)
+      .then(function(result) {
+        expect.fail('it did not reject');
+      })
+      .catch(function(error) {
+        expect(error.message).to.contain('no such file or directory ' + "'" + source + "'");
+      });
+    });
+
+    it('should not overwrite an existing file', function() {
+      let folder = 'install';
+      return installer.moveFile('temp/script', folder)
+      .then(function(result) {
+        expect.fail('it did not reject');
+      })
+      .catch(function(error) {
+        expect(error.message).to.contain('file already exists ' + "'" + folder + "'");
+      });
+    });
+  });
+
+  describe('writeFile', function() {
+    let file = path.join('temp', 'file');
+    let data = 'data';
+
+    it('should call fs#writeFile with correct arguments', function() {
+      let spy = sandbox.spy(fs, 'writeFile');
+
+      installer.writeFile(file, data);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith(file, data);
+    });
+
+    it('should resolve as true when no error occurs', function() {
+      sandbox.stub(fs, 'writeFile').yields();
+
+      return installer.moveFile(file, data)
+      .then(function(result) {
+        expect(result).to.equal(true);
+      });
+    });
+
+    it('should reject when an error occurs', function() {
+      let err = new Error('fatal error');
+      let proc = sandbox.stub(fs, 'writeFile');
+      proc.throws(err);
+
+      return installer.writeFile(file, data)
+      .then(function(result) {
+        expect.fail('it did not reject');
+      })
+      .catch(function(error) {
+        expect(error).to.equal(err);
+      });
+    });
+  });
+
+  describe('succeed', function() {
+    it('should set progress to complete when the input is truthy', function() {
+      let spy = sandbox.spy(fakeProgress, 'setComplete');
+      installer.succeed(true);
+
+      expect(spy).to.have.been.calledOnce;
+    });
+
+    it('should not succeed with a falsey input', function() {
+      let spy = sandbox.spy(fakeProgress, 'setComplete');
+      installer.succeed(false);
+
+      expect(spy).to.have.not.been.called;
+    });
+  });
+});

--- a/test/unit/model/helpers/installer-test.js
+++ b/test/unit/model/helpers/installer-test.js
@@ -7,40 +7,38 @@ import Installer from 'model/helpers/installer';
 import mockfs from 'mock-fs';
 import path from 'path';
 import Logger from 'services/logger';
+import fs from 'fs-extra';
+import child_process from 'child_process';
+import unzip from 'unzip';
 chai.use(sinonChai);
 
-let fs = require('fs-extra');
-let child_process = require('child_process');
-let unzip = require('unzip');
-
 describe('Installer', function() {
-  let installer;
-  let sandbox;
-  let fakeProgress;
+  // let sandbox;
   let infoStub, errorStub;
+
+  let fakeProgress = {
+    setStatus: function (desc) { return; },
+    setCurrent: function (val) {},
+    setLabel: function (label) {},
+    setComplete: function() {},
+    setTotalDownloadSize: function(size) {},
+    downloaded: function(amt, time) {}
+  };
+  let installer = new Installer('test', fakeProgress, () => { return 'success'; }, (err) => { return err; });
 
   before(function() {
     infoStub = sinon.stub(Logger, 'info');
     errorStub = sinon.stub(Logger, 'error');
 
     mockfs({
-      'temp': {
-        'script': 'file content here',
-        'zipFile.zip': 'content'
+      someTempFolder: {
+        somefile : 'nothing to see here'
       },
-      'install' : {}
+      anInstallFolder : {}
+    }, {
+      createCwd: false,
+      createTmp: false
     });
-
-    fakeProgress = {
-      setStatus: function (desc) { return; },
-      setCurrent: function (val) {},
-      setLabel: function (label) {},
-      setComplete: function() {},
-      setTotalDownloadSize: function(size) {},
-      downloaded: function(amt, time) {}
-    };
-
-    installer = new Installer('test', fakeProgress, () => { return 'success'; }, (err) => { return err; });
   });
 
   after(function() {
@@ -49,39 +47,34 @@ describe('Installer', function() {
     mockfs.restore();
   });
 
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create();
-  });
-
-  afterEach(function () {
-    sandbox.restore();
-  })
-
   describe('exec', function() {
     let command = 'command';
     let args = ['arg1', 'arg2', 'arg3'];
 
     it('should call child_process#exec with the correct parameters', function() {
-      let spy = sandbox.spy(child_process, 'exec');
+      let stub = sinon.stub(child_process, 'exec');
+      stub.yields();
 
       installer.exec(command, args);
 
-      expect(spy).to.have.been.calledOnce;
-      expect(spy).to.have.been.calledWith(command, args);
+      expect(stub).to.have.been.calledOnce;
+      expect(stub).to.have.been.calledWith(command, args);
+      stub.restore();
     });
 
     it('should resolve as true if no error occurs' , function() {
-      sandbox.stub(child_process, 'exec').yields();
+      let stub = sinon.stub(child_process, 'exec').yields();
 
       return installer.exec(command, args)
       .then(function(result) {
         expect(result).to.equal(true);
+        stub.restore();
       });
     });
 
     it('should reject when an error occurs', function() {
       let err = new Error('fatal error');
-      let proc = sandbox.stub(child_process, 'exec');
+      let proc = sinon.stub(child_process, 'exec');
       proc.throws(err);
 
       return installer.exec(command, args)
@@ -90,35 +83,39 @@ describe('Installer', function() {
       })
       .catch(function(error) {
         expect(error).to.equal(err);
+        proc.restore();
       });
     });
   });
 
   describe('execFile', function() {
-    let file = path.join('temp', 'script');
     let args = ['arg1', 'arg2', 'arg3'];
+    let file = path.join('someTempFolder', 'somefile');
 
     it('should call child_process#execFile with the correct parameters', function() {
-      let spy = sandbox.spy(child_process, 'execFile');
+      let stub = sinon.stub(child_process, 'execFile');
+      stub.yields();
 
       installer.execFile(file, args);
 
-      expect(spy).to.have.been.calledOnce;
-      expect(spy).to.have.been.calledWith(file, args);
+      expect(stub).to.have.been.calledOnce;
+      expect(stub).to.have.been.calledWith(file, args);
+      stub.restore();
     });
 
     it('should resolve as true if no error occurs' , function() {
-      sandbox.stub(child_process, 'execFile').yields();
+      let stub = sinon.stub(child_process, 'execFile').yields();
 
       return installer.execFile(file, args)
       .then(function(result) {
         expect(result).to.equal(true);
+        stub.restore();
       });
     });
 
     it('should reject when an error occurs', function() {
       let err = new Error('fatal error');
-      let proc = sandbox.stub(child_process, 'execFile');
+      let proc = sinon.stub(child_process, 'execFile');
       proc.throws(err);
 
       return installer.execFile(file, args)
@@ -127,45 +124,43 @@ describe('Installer', function() {
       })
       .catch(function(error) {
         expect(error).to.equal(err);
+        proc.restore();
       });
     });
   });
 
   describe('unzip', function() {
-    let file = path.join('temp', 'zipFile.zip');
-    let dir = 'install';
+    let dir = 'anInstallFolder';
+    let file = path.join('someTempFolder', 'somefile');
 
     it('should read the specified file', function() {
-      let spy = sandbox.spy(fs, 'createReadStream');
+      let stub = sinon.stub(unzip, 'Extract').yields();
+      let spy = sinon.spy(fs, 'createReadStream');
 
       installer.unzip(file, dir);
 
       expect(spy).to.have.been.calledOnce;
       expect(spy).to.have.been.calledWith(file);
+
+      stub.restore();
+      spy.restore();
     });
 
     it('should call unzip#Extract into a correct folder', function() {
-      let spy = sandbox.spy(unzip, 'Extract');
+      let stub = sinon.stub(unzip, 'Extract');
+      stub.yields();
 
       installer.unzip(file, dir);
 
-      expect(spy).to.have.been.calledOnce;
-      expect(spy).to.have.been.calledWith({ path: dir });
-    });
+      expect(stub).to.have.been.calledOnce;
+      expect(stub).to.have.been.calledWith({ path: dir });
 
-    it('should fail with an invalid zip file', function() {
-      return installer.unzip(file, dir)
-      .then(function(result) {
-        expect.fail('it did not reject');
-      })
-      .catch(function(error) {
-        expect(error.message).to.contain('invalid signature');
-      });
+      stub.restore();
     });
 
     it('should reject when an error occurs', function() {
       let err = new Error('fatal error');
-      let proc = sandbox.stub(unzip, 'Extract');
+      let proc = sinon.stub(unzip, 'Extract');
       proc.throws(err);
 
       return installer.unzip(file, dir)
@@ -179,30 +174,34 @@ describe('Installer', function() {
   });
 
   describe('moveFile', function() {
-    let source = path.join('temp', 'zipFile.zip');
-    let target = path.join('install', 'target');
+    let source = path.join('someTempFolder', 'somefile');
+    let target = path.join('anInstallFolder', 'target');
 
     it('should call fs#move with correct arguments', function() {
-      let spy = sandbox.spy(fs, 'move');
+      let stub = sinon.stub(fs, 'move');
+      stub.yields();
 
       installer.moveFile(source, target);
 
-      expect(spy).to.have.been.calledOnce;
-      expect(spy).to.have.been.calledWith(source, target);
+      expect(stub).to.have.been.calledOnce;
+      expect(stub).to.have.been.calledWith(source, target);
+
+      stub.restore();
     });
 
     it('should resolve as true when no error occurs', function() {
-      sandbox.stub(fs, 'move').yields();
+      let stub = sinon.stub(fs, 'move').yields();
 
       return installer.moveFile(source, target)
       .then(function(result) {
         expect(result).to.equal(true);
+        stub.restore();
       });
     });
 
     it('should reject when an error occurs', function() {
       let err = new Error('fatal error');
-      let proc = sandbox.stub(fs, 'move');
+      let proc = sinon.stub(fs, 'move');
       proc.throws(err);
 
       return installer.moveFile(source, target)
@@ -211,56 +210,62 @@ describe('Installer', function() {
       })
       .catch(function(error) {
         expect(error).to.equal(err);
+        proc.restore();
       });
     });
 
     it('should fail with a non-existing source', function() {
-      return installer.moveFile(source, target)
+      let src = 'file';
+      return installer.moveFile(src, target)
       .then(function(result) {
         expect.fail('it did not reject');
       })
       .catch(function(error) {
-        expect(error.message).to.contain('no such file or directory ' + "'" + source + "'");
+        expect(error.message).to.contain('no such file or directory');
       });
     });
 
     it('should not overwrite an existing file', function() {
-      let folder = 'install';
-      return installer.moveFile('temp/script', folder)
+      let folder = 'anInstallFolder';
+      return installer.moveFile(source, folder)
       .then(function(result) {
         expect.fail('it did not reject');
       })
       .catch(function(error) {
-        expect(error.message).to.contain('file already exists ' + "'" + folder + "'");
+        expect(error.message).to.contain('file already exists');
       });
     });
   });
 
   describe('writeFile', function() {
-    let file = path.join('temp', 'file');
+    let file = path.join('someTempFolder', 'somefile');
     let data = 'data';
 
     it('should call fs#writeFile with correct arguments', function() {
-      let spy = sandbox.spy(fs, 'writeFile');
+      let stub = sinon.stub(fs, 'writeFile');
+      stub.yields();
 
       installer.writeFile(file, data);
 
-      expect(spy).to.have.been.calledOnce;
-      expect(spy).to.have.been.calledWith(file, data);
+      expect(stub).to.have.been.calledOnce;
+      expect(stub).to.have.been.calledWith(file, data);
+
+      stub.restore();
     });
 
     it('should resolve as true when no error occurs', function() {
-      sandbox.stub(fs, 'writeFile').yields();
+      let stub = sinon.stub(fs, 'writeFile').yields();
 
       return installer.moveFile(file, data)
       .then(function(result) {
         expect(result).to.equal(true);
+        stub.restore();
       });
     });
 
     it('should reject when an error occurs', function() {
       let err = new Error('fatal error');
-      let proc = sandbox.stub(fs, 'writeFile');
+      let proc = sinon.stub(fs, 'writeFile');
       proc.throws(err);
 
       return installer.writeFile(file, data)
@@ -269,23 +274,26 @@ describe('Installer', function() {
       })
       .catch(function(error) {
         expect(error).to.equal(err);
+        proc.restore();
       });
     });
   });
 
   describe('succeed', function() {
     it('should set progress to complete when the input is truthy', function() {
-      let spy = sandbox.spy(fakeProgress, 'setComplete');
+      let spy = sinon.spy(fakeProgress, 'setComplete');
       installer.succeed(true);
 
       expect(spy).to.have.been.calledOnce;
+      spy.restore();
     });
 
     it('should not succeed with a falsey input', function() {
-      let spy = sandbox.spy(fakeProgress, 'setComplete');
+      let spy = sinon.spy(fakeProgress, 'setComplete');
       installer.succeed(false);
 
       expect(spy).to.have.not.been.called;
+      spy.restore();
     });
   });
 });


### PR DESCRIPTION
First step in getting out of callback hell. CDK installer rewritten using promises and common functionality moved to a separate helper class.  I'm aiming to get the 'model' classes rewritten in this manner to get rid of the callback pyramids.

@dgolovin - as the new lead - could you review this please? :)