### PR TITLE
Allow to enable DevTools in installer window

### DIFF
--- a/main/index.es6.js
+++ b/main/index.es6.js
@@ -71,7 +71,9 @@ app.on('ready', function() {
   // and load the index.html of the app.
   mainWindow.loadURL('file://' + __dirname + '/../browser/index.html');
 
-  //mainWindow.openDevTools();
+  if( process.env['PDKI_DEBUG'] !== undefined ) {
+    mainWindow.openDevTools();
+  }
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {


### PR DESCRIPTION
Use

``` shell
export PDKI_DEBUG=
```

to enable DevTools or

``` shell
unset PDKI_DEBUG

```
to disable it.