### PR TITLE
JBDS-3682 Online installer reports missing package.js file

### DIFF
--- a/browser/pages/account/controller.js
+++ b/browser/pages/account/controller.js
@@ -2,7 +2,7 @@
 
 const shell = require('electron').shell;
 let path = require('path');
-var pjson = require(path.resolve('./package.json'));
+var pjson = require(path.join(__dirname,'../package.json'));
 
 class AccountController {
   constructor($state, $http, $base64, installerDataSvc) {


### PR DESCRIPTION
Fix adds __pathname/.. to package.json file to resolve it correctly.