### PR TITLE
JBDS-3615 Run virtualbox with elevated privileges

### DIFF
--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -158,19 +158,28 @@ class VirtualBoxInstall extends InstallableItem {
 
   installMsi(installer,resolve,reject) {
     installer.progress.setStatus('Installing');
-    return installer.execFile('msiexec', [
-      '/i',
-      this.msiFile,
-      'INSTALLDIR=' + this.installerDataSvc.virtualBoxDir(),
-      '/qb!',
-      '/norestart',
-      '/Liwe',
-      path.join(this.installerDataSvc.installDir(), 'vbox.log')
-    ]).then((res) => {
-      return resolve(res);
-    }) .catch((err) => {
-      return reject(err);
-    });
+    let ps1InstallData = [
+      'Start-Process msiexec.exe "/qn /norestart /i ""' + this.msiFile + '"" '
+      + 'INSTALLDIR=""' + this.installerDataSvc.virtualBoxDir() + '"" '
+      + '/log ""' + path.join(this.installerDataSvc.installDir(), 'vbox.log') + '"""'
+      + '-Verb runas '
+      + '-Wait'
+    ].join('\r\n');
+    let vboxInstallScript = path.join(this.installerDataSvc.tempDir(), 'install-vbox.ps1');
+    return installer.writeFile(vboxInstallScript, ps1InstallData)
+        .then((result) => {
+          let args = [
+            '-ExecutionPolicy',
+            'ByPass',
+            '-File',
+            vboxInstallScript
+          ];
+          return installer.execFile('powershell', args, result);
+        }).then((result)=>{
+          return resolve(result);
+        }).catch((err) => {
+          return reject(err);
+        });
   }
 }
 


### PR DESCRIPTION
Fix introduces privilege lifting with powershell script for virtualbox
installer running in headless mode without UI. As a result request for
administrative priveleges contains 'Windows Installer' as a programm name
and 'Microsoft' as publisher. If user would run original vagrant.msi file
it would be 'program name.msi' and HashiCorp,Inc. acoordingly.