### PR TITLE
JBDS-3647 Investigate why we are including both cygwin and mingw

### DIFF
--- a/browser/main.js
+++ b/browser/main.js
@@ -78,7 +78,7 @@ let mainModule =
             installerDataSvc.addItemToInstall(
                 CygwinInstall.key(),
                 new CygwinInstall(installerDataSvc,
-                                  'http://dgolovin.github.io/mingw-ssh-rsync/ssh-rsync.zip',
+                                  'https://cygwin.com/setup-x86_64.exe',
                                   null)
             );
             installerDataSvc.addItemToInstall(

--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -17,7 +17,7 @@ class CygwinInstall extends InstallableItem {
     super('Cygwin', 720, downloadUrl, installFile);
 
     this.installerDataSvc = installerDataSvc;
-    this.downloadedFileName = 'ssh-rsync.zip';
+    this.downloadedFileName = 'cygwin.exe';
     this.downloadedFile = path.join(this.installerDataSvc.tempDir(), this.downloadedFileName);
     this.cygwinPathScript = path.join(this.installerDataSvc.tempDir(), 'set-cygwin-path.ps1');
   }
@@ -83,7 +83,7 @@ class CygwinInstall extends InstallableItem {
       '[Environment]::Exit(0)'
     ].join('\r\n');
 
-    installer.unzip(this.downloadedFile, this.installerDataSvc.cygwinDir())
+    installer.execFile(this.downloadedFile, opts)
     .then((result) => { return installer.writeFile(this.cygwinPathScript, data, result); })
     .then((result) => { return installer.execFile('powershell',
       [

--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -141,7 +141,9 @@ class VagrantInstall extends InstallableItem {
           .then((result) => {
             return installer.execFile('powershell', args, result);
           })
-          //.then((result) => { return installer.exec('setx VAGRANT_DETECTED_OS "cygwin"'); })
+          .then((result) => {
+          	return installer.exec('setx VAGRANT_DETECTED_OS "cygwin"');
+          })
           .then((result) => {
             return installer.succeed(result);
           })

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -37,7 +37,7 @@ class InstallerDataService {
     this.jdkRoot = jdkRoot || path.join(this.installRoot, 'jdk8');
     this.jbdsRoot = jbdsRoot || path.join(this.installRoot, 'DeveloperStudio');
     this.vagrantRoot = vagrantRoot || path.join(this.installRoot, 'vagrant');
-    this.cygwinRoot = cygwinRoot || path.join(this.installRoot, 'ssh-rsync');
+    this.cygwinRoot = cygwinRoot || path.join(this.installRoot, 'cygwin');
     this.cdkRoot = cdkRoot || path.join(this.installRoot, 'cdk');
     this.cdkBoxRoot = path.join(this.cdkRoot, 'boxes');
     this.ocBinRoot = path.join(this.cdkRoot, 'bin');

--- a/test/unit/model/cygwin-test.js
+++ b/test/unit/model/cygwin-test.js
@@ -83,7 +83,7 @@ describe('Cygwin installer', function() {
 
   it('should download cygwin installer to temporary folder as ssh-rsync.zip', function() {
     expect(new CygwinInstall(installerDataSvc, 'url', null).downloadedFile).to.equal(
-      path.join('tempDirectory', 'ssh-rsync.zip'));
+      path.join('tempDirectory', 'cygwin.exe'));
   });
 
   describe('when downloading cygwin', function() {
@@ -116,7 +116,7 @@ describe('Cygwin installer', function() {
 
       expect(streamSpy).to.have.been.calledOnce;
       expect(spy).to.have.been.calledOnce;
-      expect(spy).to.have.been.calledWith(path.join('tempDirectory', 'ssh-rsync.zip'));
+      expect(spy).to.have.been.calledWith(path.join('tempDirectory', 'cygwin.exe'));
 
       streamSpy.restore();
       spy.restore();
@@ -148,14 +148,14 @@ describe('Cygwin installer', function() {
       spy.restore();
     });
 
-    it('should unzip the installer with correct parameters', function() {
+    it('should run the installer with correct parameters', function() {
       let installer = new CygwinInstall(installerDataSvc, downloadUrl, null);
-      let stub = sandbox.stub(require('unzip'), 'Extract').throws('done');
-      let spy = sandbox.spy(Installer.prototype, 'unzip');
+      let stub = sandbox.stub(require('child_process'), 'execFile').throws('done');
+      let spy = sandbox.spy(Installer.prototype, 'execFile');
 
       installer.postVirtualboxInstall(fakeProgress, null, null);
 
-      expect(spy).to.have.been.calledWith(installer.downloadedFile, fakeData.cygwinDir());
+      expect(spy).to.have.been.calledWith(installer.downloadedFile, ["--no-admin", "--quiet-mode", "--only-site", "--site", "http://mirrors.xmission.com/cygwin", "--root", "install/Cygwin", "--categories", "Base", "--packages", "openssh,rsync"]);
     });
 
     it('should catch errors thrown during the installation', function(done) {

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -77,7 +77,7 @@ describe('InstallerDataService', function() {
       expect(svc.jdkRoot).to.equal(path.join(svc.installRoot, 'jdk8'));
       expect(svc.jbdsRoot).to.equal(path.join(svc.installRoot, 'DeveloperStudio'));
       expect(svc.vagrantRoot).to.equal(path.join(svc.installRoot, 'vagrant'));
-      expect(svc.cygwinRoot).to.equal(path.join(svc.installRoot, 'ssh-rsync'));
+      expect(svc.cygwinRoot).to.equal(path.join(svc.installRoot, 'cygwin'));
       expect(svc.cdkRoot).to.equal(path.join(svc.installRoot, 'cdk'));
       expect(svc.cdkBoxRoot).to.equal(path.join(svc.cdkRoot, 'boxes'));
       expect(svc.ocBinRoot).to.equal(path.join(svc.cdkRoot, 'bin'));


### PR DESCRIPTION
returning cygwin back for these reasons:
- it is the only ssh/rsync implementation that can be used to
  configure sshd service and then use version 1.0.0 of vagrant-sshfs
  to   mount the users home directory into the VM (see JBDS-3671 for
  details) ;
- it works with latest vagrant release 1.8.1, mingw based ssh/rsync
  does not. This is the going tombe a problem in case someone has it
  already installed and decided to skip vagrant installation and
  use preinstalled one.