### PR TITLE
JBDS-3690 Update to CDK Beta5

### DIFF
--- a/browser/main.js
+++ b/browser/main.js
@@ -91,10 +91,9 @@ let mainModule =
                 CDKInstall.key(),
                 new CDKInstall(installerDataSvc,
                                 $timeout,
-                                'http://cdk-builds.usersys.redhat.com/builds/03-Mar-2016/cdk.zip',
-                                'http://cdk-builds.usersys.redhat.com/builds/03-Mar-2016/rhel-7.2-server-kubernetes-vagrant-scratch-7.2-1.x86_64.vagrant-virtualbox.box',
+                                'http://cdk-builds.usersys.redhat.com/builds/09-Mar-2016/cdk-2.0.0-beta5.zip',
+                                'http://cdk-builds.usersys.redhat.com/builds/09-Mar-2016/rhel-cdk-kubernetes-7.2-21.x86_64.vagrant-virtualbox.box',
                                 'https://ci.openshift.redhat.com/jenkins/job/devenv_ami/lastSuccessfulBuild/artifact/origin/artifacts/release/',
-                                'https://github.com/redhat-developer-tooling/openshift-vagrant/archive/master.zip',
                                 'http://the.earth.li/~sgtatham/putty/latest/x86/pscp.exe',
                                 null)
             );

--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -12,27 +12,23 @@ import VagrantInstall from './vagrant';
 import Installer from './helpers/installer';
 
 class CDKInstall extends InstallableItem {
-  constructor(installerDataSvc, $timeout, cdkUrl, cdkBoxUrl, ocUrl, vagrantFileUrl, pscpUrl, installFile) {
+  constructor(installerDataSvc, $timeout, cdkUrl, cdkBoxUrl, ocUrl, pscpUrl, installFile) {
     super('CDK', 900, cdkUrl, installFile);
 
     this.installerDataSvc = installerDataSvc;
     this.$timeout = $timeout;
     this.cdkBoxUrl = cdkBoxUrl;
     this.ocUrl = ocUrl;
-    this.vagrantFileUrl = vagrantFileUrl;
     this.pscpUrl = pscpUrl;
 
     this.cdkFileName = 'cdk.zip';
     this.cdkDownloadedFile = path.join(this.installerDataSvc.tempDir(), this.cdkFileName);
 
-    this.boxName = 'rhel-cdk-kubernetes-7.2-1.x86_64.vagrant-virtualbox.box';
+    this.boxName = 'rhel-cdk-kubernetes.x86_64.vagrant-virtualbox.box';
     this.cdkBoxDownloadedFile = path.join(this.installerDataSvc.tempDir(), this.boxName);
 
     this.ocFileName = 'oc.zip';
     this.ocDownloadedFile = path.join(this.installerDataSvc.tempDir(),   this.ocFileName);
-
-    this.vagrantFileName = 'vagrantfile.zip';
-    this.vagrantDownloadedFile = path.join(this.installerDataSvc.tempDir(), this.vagrantFileName);
 
     this.pscpFileName = 'pscp.exe';
     this.pscpDownloadedFile = path.join(this.installerDataSvc.tempDir(), this.pscpFileName);
@@ -54,7 +50,7 @@ class CDKInstall extends InstallableItem {
 
     let downloadSize = 869598013;
 
-    let totalDownloads = 5;
+    let totalDownloads = 4;
 
     let downloader = new Downloader(progress, success, failure, downloadSize, totalDownloads);
     let username = this.installerDataSvc.getUsername(),
@@ -85,15 +81,6 @@ class CDKInstall extends InstallableItem {
       }, username, password);
     } else {
       this.cdkDownloadedFile = path.join(this.downloads, this.cdkFileName);
-      downloader.closeHandler();
-    }
-
-    if(!fs.existsSync(path.join(this.downloads, this.vagrantFileName))) {
-      let vagrantFileWriteStream = fs.createWriteStream(this.vagrantDownloadedFile);
-      downloader.setWriteStream(vagrantFileWriteStream);
-      downloader.download(this.vagrantFileUrl);
-    } else {
-      this.vagrantDownloadedFile = path.join(this.downloads, this.vagrantFileName);
       downloader.closeHandler();
     }
 
@@ -166,8 +153,6 @@ class CDKInstall extends InstallableItem {
 
     installer.unzip(this.cdkDownloadedFile, this.installerDataSvc.installDir())
     .then((result) => { return installer.unzip(this.ocDownloadedFile, this.installerDataSvc.ocDir(), result); })
-    .then((result) => { return installer.unzip(this.vagrantDownloadedFile, this.installerDataSvc.tempDir(), result); })
-    .then((result) => { return installer.copyFile(path.join(this.installerDataSvc.tempDir(), 'openshift-vagrant-master', 'cdk-v2'), this.installerDataSvc.cdkVagrantfileDir(), result); })
     .then((result) => { return installer.copyFile(this.cdkBoxDownloadedFile, path.join(this.installerDataSvc.cdkBoxDir(), this.boxName), result); })
     .then((result) => { return installer.copyFile(this.pscpDownloadedFile, path.join(this.installerDataSvc.ocDir(), 'pscp.exe'), result); })
     .then((result) => { return installer.writeFile(this.pscpPathScript, data, result); })
@@ -225,9 +210,7 @@ class CDKInstall extends InstallableItem {
       ).then((result) => {
         return installer.exec('vagrant box add --name cdk_v2 ' + path.join(this.installerDataSvc.cdkBoxDir(), this.boxName), opts, result);
       }).then((result) => {
-        return installer.exec('vagrant plugin install ' + path.join(this.installerDataSvc.cdkDir(), 'plugins', 'vagrant-service-manager-0.0.3.gem'), opts, result);
-      }).then((result) => {
-        return installer.exec('vagrant plugin install ' + path.join(this.installerDataSvc.cdkDir(), 'plugins', 'landrush-0.18.0.gem'), opts, result);
+        return installer.exec('vagrant plugin install ' + path.join(this.installerDataSvc.cdkDir(), 'plugins', 'vagrant-service-manager-0.0.4.gem'), opts, result);
       });
 
       return res;

--- a/browser/model/jbds.js
+++ b/browser/model/jbds.js
@@ -268,7 +268,7 @@ class JbdsInstall extends InstallableItem {
     return new Promise((resolve, reject) => {
       fs.appendFile(
         path.join(this.installerDataSvc.jbdsDir(), 'studio', 'runtime_locations.properties'),
-        'CDKServer=' + escapedPath + ',true',
+        'CDKServer=' + escapedPath + ',true\r\n',
         (err) => {
           if (err) {
             Logger.error(JbdsInstall.key() + ' - ' + err);

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -41,7 +41,7 @@ class InstallerDataService {
     this.cdkRoot = cdkRoot || path.join(this.installRoot, 'cdk');
     this.cdkBoxRoot = path.join(this.cdkRoot, 'boxes');
     this.ocBinRoot = path.join(this.cdkRoot, 'bin');
-    this.cdkVagrantRoot = path.join(this.cdkRoot, 'openshift-vagrant');
+    this.cdkVagrantRoot = path.join(this.cdkRoot, 'components', 'rhel', 'rhel-ose');
     this.cdkMarkerFile = path.join(this.cdkVagrantRoot, '.cdk');
 
     Logger.initialize(this.installRoot);

--- a/test/unit/model/jbds-test.js
+++ b/test/unit/model/jbds-test.js
@@ -245,7 +245,7 @@ describe('JBDS installer', function() {
 
       let runtimePath = path.join(installerDataSvc.jbdsDir(), 'studio', 'runtime_locations.properties');
       let escapedPath = installerDataSvc.cdkVagrantfileDir().replace(/\\/g, "\\\\").replace(/:/g, "\\:");
-      let data = 'CDKServer=' + escapedPath + ',true';
+      let data = 'CDKServer=' + escapedPath + ',true\r\n';
 
       return installer.setupCdk(helper)
       .then((result) => {

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -81,7 +81,7 @@ describe('InstallerDataService', function() {
       expect(svc.cdkRoot).to.equal(path.join(svc.installRoot, 'cdk'));
       expect(svc.cdkBoxRoot).to.equal(path.join(svc.cdkRoot, 'boxes'));
       expect(svc.ocBinRoot).to.equal(path.join(svc.cdkRoot, 'bin'));
-      expect(svc.cdkVagrantRoot).to.equal(path.join(svc.cdkRoot, 'openshift-vagrant'));
+      expect(svc.cdkVagrantRoot).to.equal(path.join(svc.cdkRoot, 'components', 'rhel', 'rhel-ose'));
       expect(svc.cdkMarkerFile).to.equal(path.join(svc.cdkVagrantRoot, '.cdk'));
     })
   });


### PR DESCRIPTION
~~Still need to check if we now can get rid of the Vagrantfile provided by the https://github.com/redhat-developer-tooling/openshift-vagrant~~
Update: Update to CDK Beta5 + use Vagrantfile provided by CDK 
See https://issues.jboss.org/browse/JBDS-3656