### PR TITLE
JBDS-3702 No numbers for VirtualBox and JDK key in requirements.json

### DIFF
--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -16,7 +16,7 @@ class JdkInstall extends InstallableItem {
     super('JDK 8', 260, downloadUrl, installFile);
 
     this.installerDataSvc = installerDataSvc;
-    this.downloadedFileName = 'jdk8.zip';
+    this.downloadedFileName = 'jdk.zip';
     this.downloadedFile = path.join(this.installerDataSvc.tempDir(), this.downloadedFileName);
   }
 

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -18,7 +18,7 @@ class VirtualBoxInstall extends InstallableItem {
 
     this.version = version;
     this.revision = revision;
-    this.downloadedFileName = 'virtualBox-' + this.version + '.exe';
+    this.downloadedFileName = 'virtualbox.exe';
     this.downloadedFile = path.join(this.installerDataSvc.tempDir(), this.downloadedFileName);
 
     this.downloadUrl = this.downloadUrl.split('${version}').join(this.version);

--- a/requirements.json
+++ b/requirements.json
@@ -23,7 +23,7 @@
     "bundle": "yes",
     "url": "https://devstudio.redhat.com/9.0/snapshots/builds/devstudio.product_9.0.mars/latest/all/jboss-devstudio-9.1.0.latest-installer-standalone.jar"
   },
-  "jdk8.zip": {
+  "jdk.zip": {
     "bundle": "yes",
     "url": "http://cdn.azul.com/zulu/bin/zulu8.13.0.5-jdk8.0.72-win_x64.zip"
   },
@@ -31,7 +31,7 @@
     "bundle": "no",
     "url": "https://releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.msi"
   },
-  "VirtualBox-5.0.8.exe": {
+  "virtualbox.exe": {
     "bundle": "no",
     "version": "5.0.8",
     "revision": "103449",


### PR DESCRIPTION
Fix renames:
1. VirtualBox-5.0.4.exe to virtualbox.exe
2. jdk8.zip to jdk.zip