### PR TITLE
Gulp task for online installer build refactored, Squirrel removed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,22 +75,8 @@ gulp.task('run', ['transpile:app'], function(cb) {
   exec(path.join('node_modules', '.bin') + path.sep + 'electron .',createExecCallback(cb));
 });
 
-gulp.task('package', function(cb) {
-  var cmd = path.join('node_modules', '.bin') + path.sep + 'electron-installer-squirrel-windows ./' + buildFolderRoot + buildFileNamePrefix ;
-  cmd += ' --out=./' + buildFolderRoot + ' --name=developer_platform --exe=' + artifactName + '.exe';
-  cmd += ' --overwrite --authors="Red Hat Developer Tooling Group"';
-  cmd += ' --loading_gif=./resources/loading.gif';
-
-  exec(cmd,createExecCallback(cb));
-});
-
-// Create bundled installer
-gulp.task('package-bundle', function() {
-  return runSequence('prefetch', '7zip-sfx');
-});
-
 // Wrap electrom generated app to self extractring 7zip archive
-gulp.task('7zip-sfx', function (cb) {
+gulp.task('package', function (cb) {
   let zaRoot = path.resolve(buildFolderRoot)
   let zaElectronPackage = path.join(zaRoot, 'DeveloperPlatformInstaller-win32-x64');
   let zaZip = path.join(zaRoot, '7za920.zip');
@@ -135,6 +121,10 @@ gulp.task('7zip-sfx', function (cb) {
   });
 });
 
+// Create bundled installer
+gulp.task('package-bundle', function() {
+  return runSequence('prefetch', 'package');
+});
 
 gulp.task('test', function() {
   return runSequence('create-electron-symlink', 'unit-test', 'delete-electron-symlink', 'browser-test');

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "babel": "^5.8.35",
     "chai": "^3.4.1",
     "del": "^2.0.2",
-    "electron-installer-squirrel-windows": "^1.3.0",
     "electron-packager": "^5.2.0",
     "electron-prebuilt": "0.37.2",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Both online and bundled installer binaries are created in the same way, the only difference is that the second one bundles pre-downloaded files.