### PR TITLE
Avoid jspm 0.16.32 which causes build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-zip": "^3.2.0",
     "jasmine-core": "^2.3.4",
     "jquery": "^2.2.0",
-    "jspm": "^0.16.10",
+    "jspm": "0.16.31",
     "karma": "^0.13.15",
     "karma-babel-preprocessor": "^5.2.2",
     "karma-electron-launcher": "0.1.0",


### PR DESCRIPTION
Jspm 0.16.32 causes build and run errors right now - workaround to revert to 0.16.31 until a proper solution is found.