### PR TITLE
JBDS-3741 Developer Studio should install under developer-studio

### DIFF
--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -35,7 +35,7 @@ class InstallerDataService {
     this.installRoot = installRoot || this.installRoot;
     this.vboxRoot = vboxRoot || path.join(this.installRoot, 'virtualbox');
     this.jdkRoot = jdkRoot || path.join(this.installRoot, 'jdk8');
-    this.jbdsRoot = jbdsRoot || path.join(this.installRoot, 'DeveloperStudio');
+    this.jbdsRoot = jbdsRoot || path.join(this.installRoot, 'developer-studio');
     this.vagrantRoot = vagrantRoot || path.join(this.installRoot, 'vagrant');
     this.cygwinRoot = cygwinRoot || path.join(this.installRoot, 'cygwin');
     this.cdkRoot = cdkRoot || path.join(this.installRoot, 'cdk');

--- a/test/unit/model/jbds-test.js
+++ b/test/unit/model/jbds-test.js
@@ -19,7 +19,7 @@ describe('JBDS installer', function() {
   let fakeData = {
     tempDir: function() { return 'tempDirectory'; },
     installDir: function() { return 'installationFolder'; },
-    jbdsDir: function() { return 'installationFolder/DeveloperStudio'; },
+    jbdsDir: function() { return 'installationFolder/developer-studio'; },
     jdkDir: function() { return 'install/jdk8'; },
     getInstallable: function(key) {},
     cdkVagrantfileDir: function() {}
@@ -29,7 +29,7 @@ describe('JBDS installer', function() {
   installerDataSvc.tempDir.returns('tempDirectory');
   installerDataSvc.installDir.returns('installationFolder');
   installerDataSvc.jdkDir.returns('install/jdk8');
-  installerDataSvc.jbdsDir.returns('installationFolder/DeveloperStudio');
+  installerDataSvc.jbdsDir.returns('installationFolder/developer-studio');
   installerDataSvc.cdkVagrantfileDir.returns('installationFolder/cdk/vagrant');
 
   let fakeProgress = {

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -75,7 +75,7 @@ describe('InstallerDataService', function() {
 
       expect(svc.vboxRoot).to.equal(path.join(svc.installRoot, 'virtualbox'));
       expect(svc.jdkRoot).to.equal(path.join(svc.installRoot, 'jdk8'));
-      expect(svc.jbdsRoot).to.equal(path.join(svc.installRoot, 'DeveloperStudio'));
+      expect(svc.jbdsRoot).to.equal(path.join(svc.installRoot, 'developer-studio'));
       expect(svc.vagrantRoot).to.equal(path.join(svc.installRoot, 'vagrant'));
       expect(svc.cygwinRoot).to.equal(path.join(svc.installRoot, 'cygwin'));
       expect(svc.cdkRoot).to.equal(path.join(svc.installRoot, 'cdk'));


### PR DESCRIPTION
Fix moves Developer Studio default installtion folder to developer-studio
and updates unit tests to pass.