### PR TITLE
JBDS-3742 Cygwin setup executable should be installed as well

### DIFF
--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -67,6 +67,8 @@ class CygwinInstall extends InstallableItem {
       '--no-admin',
       '--quiet-mode',
       '--only-site',
+      '-l',
+      path.join(this.installerDataSvc.cygwinDir(),'packages'),
       '--site',
       'http://mirrors.xmission.com/cygwin',
       '--root',
@@ -83,17 +85,21 @@ class CygwinInstall extends InstallableItem {
       '[Environment]::Exit(0)'
     ].join('\r\n');
 
-    installer.execFile(this.downloadedFile, opts)
-    .then((result) => { return installer.writeFile(this.cygwinPathScript, data, result); })
-    .then((result) => { return installer.execFile('powershell',
-      [
-        '-ExecutionPolicy',
-        'ByPass',
-        '-File',
-        this.cygwinPathScript
-      ], result); })
-    .then((result) => { return installer.succeed(result); })
-    .catch((error) => { return installer.fail(error); });
+    let originalExecFile = path.join(this.installerDataSvc.cygwinDir(),'setup-x86_64.exe');
+    installer.execFile(
+      this.downloadedFile, opts
+    ).then((result) => {
+      return installer.copyFile(
+        this.downloadedFile, originalExecFile, true);
+    }).then((result) => {
+      return installer.writeFile(this.cygwinPathScript, data, result);
+    }).then((result) => { return installer.execFile('powershell',
+      ['-ExecutionPolicy','ByPass','-File',this.cygwinPathScript], result);
+    }).then((result) => {
+      return installer.succeed(result);
+    }).catch((error) => {
+      return installer.fail(error);
+    });
   }
 }
 

--- a/test/unit/model/cygwin-test.js
+++ b/test/unit/model/cygwin-test.js
@@ -158,7 +158,8 @@ describe('Cygwin installer', function() {
       installer.postVirtualboxInstall(fakeProgress, null, null);
 
       expect(spy).to.have.been.calledWith(installer.downloadedFile,
-        ["--no-admin", "--quiet-mode", "--only-site",
+        ["--no-admin", "--quiet-mode", "--only-site", '-l',
+         path.join(installerDataSvc.cygwinDir(),'packages'),
          "--site", "http://mirrors.xmission.com/cygwin",
          "--root", "install/Cygwin", "--categories", "Base",
          "--packages", "openssh,rsync"]);


### PR DESCRIPTION
Fix adds additional command to cygwin install code to copy
downloaded setup file to cygwin target dir with original name.