### PR TITLE
Fix jspm install so the builds may succeed

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bower": "1.7.7",
     "fs-extra": "0.26.7",
     "glob": "7.0.3",
+    "jspm-npm": "git+https://github.com/jrichter1/npm.git#fix-gzip-0.16",
     "patternfly": "3.3.2",
     "request": "2.69.0",
     "unzip": "0.1.11",


### PR DESCRIPTION
This immediate patch is to fix the build failures on npm install. Note that it is supposed to be a temporary solution to an in-depth problem which would require a more complex solution that we should defer to after the initial release. 