### PR TITLE
Remove patternfly and bower from dependencies in favor of jspm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,9 @@
     "ui-test": "gulp ui-test"
   },
   "dependencies": {
-    "bower": "1.7.7",
     "fs-extra": "0.26.7",
     "glob": "7.0.3",
     "jspm-npm": "git+https://github.com/jrichter1/npm.git#fix-gzip-0.16",
-    "patternfly": "3.3.2",
     "request": "2.69.0",
     "unzip": "0.1.11",
     "replace-in-file": "1.0.2"


### PR DESCRIPTION
This should solve the windows errors when installing patternfly/bower.