### PR TITLE
Check requirements URLs before building

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -221,17 +221,17 @@ gulp.task('unzip-resource-hacker', ['download-resource-hacker'], function() {
 gulp.task('prepare-resource-hacker', ['unzip-resource-hacker', 'download-resource-hacker']);
 
 // Create stub installer that will then download all the requirements
-gulp.task('package-simple', function() {
+gulp.task('package-simple', ['check-requirements'], function() {
   return runSequence('clean', 'generate', 'package', 'cleanup');
 });
 
   // Create bundled installer
-gulp.task('package-bundle', function() {
+gulp.task('package-bundle', ['check-requirements'], function() {
   return runSequence('clean', 'generate', 'prefetch', 'package', '7zip-cleanup');
 });
 
 // Create both installers
-gulp.task('dist', function() {
+gulp.task('dist', ['check-requirements'], function() {
   return runSequence('clean', 'generate', 'package', 'prefetch', 'package', 'cleanup');
 });
 
@@ -302,3 +302,8 @@ gulp.task('prefetch', function(cb) {
   }
   artifactType = "-bundle";
 });
+
+//check if URLs in requirements.json return 200 and generally point to their appropriate tools
+gulp.task('check-requirements', function(cb) {
+  return exec('node test/check-requirements.js', createExecCallback(cb, false));
+})

--- a/test/check-requirements.js
+++ b/test/check-requirements.js
@@ -1,0 +1,84 @@
+'use strict';
+
+let reqs = require('../requirements.json');
+let request = require("request");
+
+let minSizes = new Object();
+let data = new Object();
+let fileNames = new Object();
+let count = 0;
+
+function checkRequirements() {
+  for (var attribute in reqs) {
+    data[attribute] = reqs[attribute].url;
+    count++;
+  }
+
+  //to check if the url looks like it points to what it is supposed to
+  fileNames['cdk.zip'] = 'cdk';
+  fileNames['rhel-vagrant-virtualbox.box'] = 'rhel-cdk';
+  fileNames['oc.zip'] = 'origin-client-tools';
+  fileNames['pscp.exe'] = 'pscp.exe';
+  fileNames['cygwin.exe'] = 'cygwin';
+  fileNames['jbds.jar'] = 'devstudio';
+  fileNames['jdk.zip'] = 'openjdk';
+  fileNames['vagrant.msi'] = 'vagrant';
+  fileNames['virtualbox.exe'] = 'virtualbox';
+
+  //to check if the files are rougly the size the should be
+  minSizes['cdk.zip'] = 50 * 1024;
+  minSizes['rhel-vagrant-virtualbox.box'] = 800 * 1024 * 1024;
+  minSizes['oc.zip'] = 10 * 1024 * 1024;
+  minSizes['pscp.exe'] = 300 * 1024;
+  minSizes['cygwin.exe'] = 500 * 1024;
+  minSizes['jbds.jar'] = 400 * 1024 * 1024;
+  minSizes['jdk.zip'] = 50 * 1024 *1024;
+  minSizes['vagrant.msi'] = 120 * 1024 * 1024;
+  minSizes['virtualbox.exe'] = 100 * 1024 * 1024;
+
+  console.log('-------------------------------');
+  console.log('Checking download URLs');
+  for (var key in data) {
+    checkFileName(key);
+    checkUrl(key);
+  }
+}
+
+function checkFileName(key) {
+  if (!data[key].includes(fileNames[key])) {
+    throw new Error(key + ' - the url does not contain ' + fileNames[key] + ': ' + data[key]);
+  }
+}
+
+function checkUrl(key) {
+  let req = request.get(data[key])
+  .on('response', function(response) {
+    let size = response.headers['content-length'];
+    if (response.statusCode !== 200) {
+      req.abort()
+      throw new Error(key + ' url returned code ' + response.statusCode);
+    }
+    console.log(key + ' - url: ' + data[key]);
+    console.log(key + ' - size: ' + size + 'B');
+    console.log();
+
+    if (size < minSizes[key]) {
+      req.abort()
+      throw new Error(key + ' is unexpectedly small with just ' + size + ' bytes in size');
+    } else {
+      req.abort()
+    }
+  })
+  .on('end', function() {
+    if (--count === 0) {
+      console.log('Checking download URLs complete');
+      console.log('-------------------------------');
+    }
+  })
+  .on('error', function(err) {
+    req.abort()
+    throw err;
+  });
+}
+
+checkRequirements();


### PR DESCRIPTION
To avoid certain situations that have arisen throughout the development, this PR aims to check the requirements before building so the urls:
 - respond with 200
 - point to a file with roughly the size we expect
 - contain some text specific to the tool that should be downloaded (i.e. vagrant url contains 'vagrant' - we've been there before :) )