### PR TITLE
Fix vagrant setup commands not all running in sequence

### DIFF
--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -164,7 +164,7 @@ class VagrantInstall extends InstallableItem {
     .then((result) => {
       return installer.execFile('powershell', args, result);
     }).then((result) => {
-      installer.exec('setx VAGRANT_DETECTED_OS "cygwin"')
+      return installer.exec('setx VAGRANT_DETECTED_OS "cygwin"');
     }).then((result) => {
       return installer.succeed(true);
     }).catch((result) => {


### PR DESCRIPTION
Vagrant setup reports complete before 'setx VAGRANT_DETECTED_OS "cygwin"' is called. This PR should fix that.