### PR TITLE
JBDS-3800 Check SHA256 checksums for downloaded vagrant and virtualbox

### DIFF
--- a/browser/main.js
+++ b/browser/main.js
@@ -93,7 +93,8 @@ let mainModule =
                     installerDataSvc,
                     reqs['virtualbox.exe'].url,
                     null,
-                    'virtualbox')
+                    'virtualbox',
+                    reqs['virtualbox.exe'].sha256sum)
             );
 
             installerDataSvc.addItemToInstall(
@@ -111,7 +112,8 @@ let mainModule =
                     installerDataSvc,
                     reqs['vagrant.msi'].url,
                     null,
-                    'vagrant')
+                    'vagrant',
+                    reqs['vagrant.msi'].sha256sum)
             );
 
             installerDataSvc.addItemToInstall(

--- a/browser/model/helpers/hash.js
+++ b/browser/model/helpers/hash.js
@@ -1,0 +1,20 @@
+const crypto = require('crypto');
+const fs = require('fs-extra');
+
+class Hash {
+  SHA256(filename, done) {
+    var hash = crypto.createHash('sha256');
+    var readStream = fs.createReadStream(filename);
+    readStream.on('readable', function () {
+      var chunk;
+      while (null !== (chunk = readStream.read())) {
+        hash.update(chunk);
+      }
+    }).on('end', function () {
+      var hashstring = hash.digest('hex');
+      done(hashstring);
+    });
+  }
+}
+
+export default Hash;

--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -13,7 +13,7 @@ import Util from './helpers/util';
 import Version from './helpers/version';
 
 class VagrantInstall extends InstallableItem {
-  constructor(installerDataSvc, downloadUrl, installFile, targetFolderName) {
+  constructor(installerDataSvc, downloadUrl, installFile, targetFolderName, sha256) {
     super('vagrant',
           'Vagrant',
           'v1.7',
@@ -32,6 +32,7 @@ class VagrantInstall extends InstallableItem {
     this.minimumVersion = "1.7.4";
     this.version = "1.7.4";
     this.existingVersion = "";
+    this.sha256 = sha256;
   }
 
   static key() {
@@ -100,7 +101,7 @@ class VagrantInstall extends InstallableItem {
       let downloadSize = 199819264;
       let downloader = new Downloader(progress, success, failure, downloadSize);
       downloader.setWriteStream(writeStream);
-      downloader.download(this.downloadUrl);
+      downloader.download(this.downloadUrl,this.downloadedFile,this.sha256);
     } else {
       this.downloadedFile = this.bundledFile;
       success();

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -12,7 +12,7 @@ import Util from './helpers/util';
 import Version from './helpers/version';
 
 class VirtualBoxInstall extends InstallableItem {
-  constructor(version, revision, installerDataSvc, downloadUrl, installFile, targetFolderName) {
+  constructor(version, revision, installerDataSvc, downloadUrl, installFile, targetFolderName, sha256) {
     super('virtualbox',
           'Oracle VirtualBox',
           'v5.0.8',
@@ -34,6 +34,7 @@ class VirtualBoxInstall extends InstallableItem {
     this.downloadUrl = this.downloadUrl.split('${revision}').join(this.revision);
 
     this.msiFile = path.join(this.installerDataSvc.tempDir(), '/VirtualBox-' + this.version + '-r' + this.revision + '-MultiArch_amd64.msi');
+    this.sha256 = sha256;
   }
 
   static key() {
@@ -137,7 +138,7 @@ class VirtualBoxInstall extends InstallableItem {
       let writeStream = fs.createWriteStream(this.downloadedFile);
       let downloader = new Downloader(progress, success, failure);
       downloader.setWriteStream(writeStream);
-      downloader.download(this.downloadUrl);
+      downloader.download(this.downloadUrl,this.downloadedFile,this.sha256);
     } else {
       this.downloadedFile = this.bundledFile;
       success();

--- a/browser/pages/install/controller.js
+++ b/browser/pages/install/controller.js
@@ -40,6 +40,7 @@ class InstallController {
       },
       (error) => {
         Logger.error(installableKey + ' failed to download: ' + error);
+        progress.setStatus("Failed");
       }
     )
   }


### PR DESCRIPTION
This fix adds checksum only for vagrant.msi and virtualbox.exe files all other files downloaded during build with checksum verification against sha256 hex stored in requirements.js