### PR TITLE
JBDS-3852 - Add mocked installation option

### DIFF
--- a/browser/mockup/override.js
+++ b/browser/mockup/override.js
@@ -1,0 +1,71 @@
+'use strict';
+
+import JdkInstall from '../model/jdk-install';
+import JbdsInstall from '../model/jbds';
+import VagrantInstall from '../model/vagrant';
+import VirtualBoxInstall from '../model/virtualbox';
+import CygwinInstall from '../model/cygwin';
+import CDKInstall from '../model/cdk';
+
+/*
+  Used to override model methods to fake the actual installation using monkey-patching.
+  !!! FOR TESTING PURPOSES ONLY - DO NOT USE IN PRODUCTION !!!
+*/
+export class OverrideService {
+  constructor() {
+    this.model = {};
+    this.model[JdkInstall.key()] = JdkInstall.prototype;
+    this.model[JbdsInstall.key()] = JbdsInstall.prototype;
+    this.model[VagrantInstall.key()] = VagrantInstall.prototype;
+    this.model[VirtualBoxInstall.key()] = VirtualBoxInstall.prototype;
+    this.model[CygwinInstall.key()] = CygwinInstall.prototype;
+    this.model[CDKInstall.key()] = CDKInstall.prototype;
+
+    this.values = require('./mockup/results.json');
+  }
+
+  overrideModel() {
+    for (var key in this.model) {
+      let fakeModel = this.values[key];
+
+      this.overrideTask(key, "downloadInstaller", fakeModel.download.result, fakeModel.download.time, fakeModel.download.skip);
+      this.overrideTask(key, "install", fakeModel.install.result, fakeModel.install.time);
+      this.overrideTask(key, "setup", fakeModel.setup.result, fakeModel.setup.time);
+    }
+  }
+
+  overrideTask(key, task, resolution, time, skip) {
+    this.overrideMethod(this.model[key], task, function(original) {
+      if(task === "downloadInstaller" && skip) {
+        return function(progress, success, failure) {
+          success();
+        }
+      } else {
+        return function(progress, success, failure) {
+          console.log('Placeholder method for ' + key + ' ' + task);
+
+          let status = task === "downloadInstaller" ? "Pretending to be  Downloading"
+            : (task === "install" ? "Pretending to be Installing" : "Pretending to be Setting up");
+          progress.setStatus(status);
+
+          setTimeout(function () {
+            if (resolution === "success") {
+              if (task === "setup") {
+                progress.setComplete();
+              }
+              success();
+            } else {
+              progress.setStatus('Pretending to have Failed');
+              failure();
+            }
+          }, time);
+        }
+      }
+    });
+  }
+
+  overrideMethod(object, methodName, callback) {
+    object[methodName] = callback(object[methodName])
+  }
+
+}

--- a/browser/mockup/results.json
+++ b/browser/mockup/results.json
@@ -1,0 +1,97 @@
+{
+  "cdk": {
+    "download": {
+      "skip": true,
+      "result": "success",
+      "time": 5000
+    },
+    "install": {
+      "result": "success",
+      "time": 13000
+    },
+    "setup": {
+      "result": "success",
+      "time": 1000
+    }
+  },
+
+  "cygwin": {
+    "download": {
+      "skip": true,
+      "result": "success",
+      "time": 2000
+    },
+    "install": {
+      "result": "success",
+      "time": 15000
+    },
+    "setup": {
+      "result": "success",
+      "time": 0
+    }
+  },
+
+  "jbds": {
+    "download": {
+      "skip": true,
+      "result": "success",
+      "time": 5000
+    },
+    "install": {
+      "result": "success",
+      "time": 20000
+    },
+    "setup": {
+      "result": "success",
+      "time": 1000
+    }
+  },
+
+  "jdk": {
+    "download": {
+      "skip": true,
+      "result": "success",
+      "time": 2000
+    },
+    "install": {
+      "result": "success",
+      "time": 1000
+    },
+    "setup": {
+      "result": "success",
+      "time": 0
+    }
+  },
+
+  "vagrant": {
+    "download": {
+      "skip": false,
+      "result": "success",
+      "time": 3000
+    },
+    "install": {
+      "result": "success",
+      "time": 16000
+    },
+    "setup": {
+      "result": "success",
+      "time": 0
+    }
+  },
+
+  "virtualbox": {
+    "download": {
+      "skip": false,
+      "result": "success",
+      "time": 3000
+    },
+    "install": {
+      "result": "success",
+      "time": 8000
+    },
+    "setup": {
+      "result": "success",
+      "time": 0
+    }
+  }
+}

--- a/browser/pages/account/account.html
+++ b/browser/pages/account/account.html
@@ -1,6 +1,11 @@
 <header class="login-header">
   <div class="login-title">
     <img class="branding-title" src="images/RHDSP.svg"/><span class="login-title-post-text">BETA</span>
+
+    <div class="help-block" ng-show="acctCtrl.isMockRun()">
+      <span class="pficon pficon-warning-triangle-o"></span>
+      <strong>Mocked installation mode - nothing will be installed for real</strong>
+    </div>
   </div>
   <img class="branding branding-login" src="images/logo_RHD_RGB_default.svg"/>
 </header>

--- a/browser/pages/account/controller.js
+++ b/browser/pages/account/controller.js
@@ -28,7 +28,7 @@ class AccountController {
     this.pdkVersion = pjson.version;
     this.isLoginBtnClicked = false;
   }
-  
+
   login() {
     this.authFailed = false;
     this.tandcNotSigned = false;
@@ -77,6 +77,10 @@ class AccountController {
   handleHttpFailure() {
     this.authFailed = true;
     this.isLoginBtnClicked = false;
+  }
+
+  isMockRun() {
+    return (process.env['PDKI_MOCK'] === 'true' || process.env['PDKI_MOCK'] === '1');
   }
 }
 


### PR DESCRIPTION
Adds an option where the installer pretends it is doing some actual work.
 - detection is circumvented on other platforms than windows (so it can run anywhere)
 - download, install and setup routines are replaced using monkey patching
 - to initiate, set/export an environment property PDKI_MOCK=1 (or true)
 - using the results.json file one can configure what component shall succeed/fail on what method and how long the methods shall take to 'execute'