### PR TITLE
JBDS-3696 Browse buttons should not respond when a file dialog is opened

### DIFF
--- a/browser/pages/location/controller.js
+++ b/browser/pages/location/controller.js
@@ -33,7 +33,8 @@ class LocationController {
   }
 
   selectFolder() {
-    let selection = dialog.showOpenDialog({
+    let selection = dialog.showOpenDialog(
+      remote.getCurrentWindow(),{
       properties: [ 'openDirectory' ],
       defaultPath: this.folder
     });


### PR DESCRIPTION
Fix makes dialog modal for main installer window, so there is no
way to select it.