### PR TITLE
JBDS-3835 Installer: recursively installation folder creation needed

### DIFF
--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -7,6 +7,7 @@ let os = require('os');
 let path = require('path');
 let fs = require('fs');
 let electron = require('electron');
+var mkdirp = require('mkdirp');
 
 class InstallerDataService {
   constructor($state) {
@@ -44,9 +45,8 @@ class InstallerDataService {
     this.cdkMarkerFile = path.join(this.cdkVagrantRoot, '.cdk');
 
     if (!fs.existsSync(this.installRoot)) {
-      fs.mkdirSync(this.installRoot);
+      mkdirp.sync(path.resolve(this.installRoot));
     }
-    
     Logger.initialize(this.installRoot);
   }
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
       "angular-base64": "github:ninjatronic/angular-base64@2.0.5",
       "angular-ui-router": "github:angular-ui/ui-router@0.2.18",
       "font-awesome": "npm:font-awesome@4.5.0",
+      "mkdirp": "npm:mkdirp@0.5.1",
       "patternfly": "npm:patternfly@2.6.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Fix creates target folder with mkdirp.sync method.