### PR TITLE
JBDS-3803 Add JavaVM version detection and validation

### DIFF
--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -36,7 +36,7 @@ class JdkInstall extends InstallableItem {
     //this.addOption('install',this.version,this.installerDataSvc.jdkDir());
     //this.addOption('detected', this.minimumVersion, '', true);
   }
-  
+
   isSkipped() {
     let t = this.selectedOption === 'detected';
     return t;

--- a/browser/pages/confirm/confirm.html
+++ b/browser/pages/confirm/confirm.html
@@ -360,7 +360,7 @@
            ng-class="{'dotted-panel':checkboxModel.jdk.hasOption('detected')&&checkboxModel.jdk.selectedOption === 'detected'}">
            <!--ng-click="checkboxModel.jdk.changeIsCollapsed()">-->
            <div class="checkbox-container verticalLine">
-             <input type="checkbox" ng-model="checkboxModel.jdk.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
+             <input type="checkbox" ng-disabled="!checkboxModel.jdk.hasOption('detected') && checkboxModel.jbds.selectedOption === 'install' || checkboxModel.jdk.hasOption('detected') && !checkboxModel.jdk.option.detected.valid && checkboxModel.jbds.selectedOption === 'install'" ng-model="checkboxModel.jdk.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
            </div>
         <div class="checkbox-container" ng-show="false">
           <div id="arrow-jdk" class="arrow" ng-class="{'arrow-down':!checkboxModel.jdk.isCollapsed}" aria-label="Toggle ngHide"></div>
@@ -374,13 +374,13 @@
               <div ng-show="checkboxModel.jdk.option.detected.warning!=='' && checkboxModel.jdk.selectedOption === 'detected'" class="has-warning">
                 <div class="help-block">
                   <span class="pficon pficon-warning-triangle-o"></span>
-                  <span>Newer than recommended!</span>
+                  <span>Newer than required!</span>
                 </div>
               </div>
               <div ng-show="checkboxModel.jdk.option.detected.error!=='' && checkboxModel.jdk.selectedOption === 'detected'" class="has-warning">
                 <div class="help-block">
                 <span class="pficon pficon-warning-triangle-o"></span>
-                  <span>Older than recommended!</span>
+                  <span>Older than required!</span>
                 </div>
               </div>
             </div>

--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -65,9 +65,13 @@ class ConfirmController {
       return $scope.checkboxModel.jbds.selectedOption;
     },(nVal,oVal)=>{
       if(nVal=='install') {
-        // if jdk detected and valid use it else switch to included version
-        if(!$scope.checkboxModel.jdk.isConfigured()) {
-          $scope.checkboxModel.jdk.selectedOption = 'install';
+        let jdk = $scope.checkboxModel.jdk;
+        // if jdk is not selected for install and there is no detected version
+        if(jdk.selectedOption == 'detected' && !jdk.hasOption('detected')
+          // or java detected but not valid
+          || jdk.hasOption('detected') && !jdk.option.detected.valid) {
+          // force to install included version
+          jdk.selectedOption = 'install';
         }
       }
     });


### PR DESCRIPTION
Disable OpenJDK checkbox in case no JavaVM detected or detected version is invalid.
Prefer detected java if detected version is valid..