### PR TITLE
JBDS-3926 cache build tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ jspm_packages
 transpiled
 package
 build
+tools
 browser/config.js
 test/jspm-config.js
 .idea

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,13 +33,14 @@ var buildFileNamePrefix = artifactName + '-' + artifactPlatform + '-' + artifact
 var buildFolder = buildFolderRoot + buildFileNamePrefix;
 // use folder outside buildFolder so that a 'clean' task won't wipe out the cache
 var prefetchFolder = 'requirements-cache';
+let toolsFolder = 'tools';
 let buildFolderPath = path.resolve(buildFolderRoot);
 
 let zaRoot = path.resolve(buildFolderRoot);
-let zaZip = path.join(zaRoot, '7za920.zip');
+let zaZip = path.join(toolsFolder, '7zip.zip');
 let zaExe = path.join(zaRoot, '7za.exe');
 let zaSfx = path.join(zaRoot, '7zS.sfx');
-let zaExtra7z = path.join(zaRoot, '7z920_extra.7z');
+let zaExtra7z = path.join(toolsFolder, '7zip-extra.zip');
 let zaElectronPackage = path.join(zaRoot, artifactName + '-win32-x64');
 let bundled7z = path.join(zaRoot, artifactName +'-win32-x64.7z');
 let installerExe = resolveInstallerExePath('');
@@ -121,18 +122,10 @@ gulp.task('run', ['transpile:app'], function(cb) {
   exec(path.join('node_modules', '.bin') + path.sep + 'electron transpiled',createExecCallback(cb));
 });
 
-gulp.task('download-7zip', function(cb) {
-  return downloadFile(reqs['7zip.zip'].url, zaZip, cb);
-});
-
 gulp.task('unzip-7zip', function() {
   return gulp.src(zaZip)
       .pipe(unzip({ filter : function(entry){ return minimatch(entry.path, "**/7za.exe") } }))
       .pipe(gulp.dest(buildFolderRoot));
-});
-
-gulp.task('download-7zip-extra', function(cb) {
-  return downloadFile(reqs['7zip-extra.zip'].url, zaExtra7z, cb);
 });
 
 gulp.task('unzip-7zip-extra', function(cb) {
@@ -142,8 +135,7 @@ gulp.task('unzip-7zip-extra', function(cb) {
 });
 
 gulp.task('prepare-tools', function(cb) {
-  runSequence(['download-7zip', 'download-7zip-extra'],
-    ['unzip-7zip'], 'unzip-7zip-extra', cb);
+  runSequence('prefetch-tools', ['unzip-7zip'], 'unzip-7zip-extra', cb);
 });
 
 // wrap electron-generated app to 7zip archive
@@ -271,32 +263,47 @@ gulp.task('create-prefetch-cache-dir',function() {
   }
 });
 
+gulp.task('create-tools-dir',function() {
+  if (!fs.existsSync(toolsFolder)) {
+     mkdirp(toolsFolder);
+  }
+});
+
 // prefetch all the installer dependencies so we can package them up into the .exe
-gulp.task('prefetch',['create-prefetch-cache-dir'], function() {
+gulp.task('prefetch', ['create-prefetch-cache-dir'], function() {
+  return prefetch('yes', prefetchFolder);
+});
+
+gulp.task('prefetch-tools', ['create-tools-dir'], function() {
+  return prefetch('tools', toolsFolder);
+});
+
+function prefetch(bundle, targetFolder) {
   let promises = new Set();
   for (let key in reqs) {
-    if (reqs[key].bundle === 'yes') {
+    if (reqs[key].bundle === bundle) {
       let currentUrl = reqs[key].url;
-      let currentFile = path.join(prefetchFolder, key);
-      promises.add(new Promise((resolve,reject)=>{
+      let currentFile = path.join(targetFolder, key);
+      promises.add(new Promise((resolve,reject) => {
         // if file is already downloaded, check its sha against the stored one
-          downloadAndReadSHA256(key + ".sha256", reqs[key].sha256sum, reject, (currentSHA256)=>
-          {
-            // console.log('[DEBUG] SHA256SUM for '+key+' = ' + currentSHA256);
-            isExistingSHA256Current(currentFile, currentSHA256, (dl)=>
-              dl ? resolve(true) : downloadFileAndCreateSha256(key, reqs[key].url, resolve, reject)
-            );
+        downloadAndReadSHA256(targetFolder, key + ".sha256", reqs[key].sha256sum, reject, (currentSHA256) => {
+          // console.log('[DEBUG] SHA256SUM for '+key+' = ' + currentSHA256);
+          isExistingSHA256Current(currentFile, currentSHA256, (dl) => {
+            dl ? resolve(true) : downloadFileAndCreateSha256(targetFolder, key, reqs[key].url, resolve, reject)
           });
+        });
       }));
     }
   }
-  return Promise.all(promises).then((result)=>
-    installerExe = resolveInstallerExePath('-bundle')
-  );
-});
+  return Promise.all(promises).then((result) => {
+    if (bundle === 'yes') {
+      installerExe = resolveInstallerExePath('-bundle');
+    }
+  });
+}
 
-function downloadAndReadSHA256(fileName, reqURL,  reject, processResult) {
-  let currentFile = path.join(prefetchFolder, fileName);
+function downloadAndReadSHA256(targetFolder, fileName, reqURL,  reject, processResult) {
+  let currentFile = path.join(targetFolder, fileName);
   var currentSHA256 = 'NOSHA256SUM';
   if (reqURL.length == 64 && reqURL.indexOf("http")<0 && reqURL.indexOf("ftp")<0)
   {
@@ -318,8 +325,8 @@ function downloadAndReadSHA256(fileName, reqURL,  reject, processResult) {
   }
 }
 
-function downloadFileAndCreateSha256(fileName, reqURL, resolve, reject) {
-  let currentFile = path.join(prefetchFolder, fileName);
+function downloadFileAndCreateSha256(targetFolder, fileName, reqURL, resolve, reject) {
+  let currentFile = path.join(targetFolder, fileName);
   var currentSHA256 = '';
   console.log('[INFO] Download ' + reqURL + ' to ' + currentFile);
   downloadFile(reqURL, currentFile, (err, res)=>{

--- a/requirements.json
+++ b/requirements.json
@@ -84,21 +84,21 @@
   "7zip.zip": {
     "name": "7zip",
     "description": "7Zip Command Line Version",
-    "bundle": "no",
+    "bundle": "tools",
     "version": "9.20",
     "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/9.20/7za920.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsevenzip%2Ffiles%2F7-Zip%2F9.20%2F",
     "filename": "7za920.zip",
-    "sha256sum": "",
+    "sha256sum": "2a3afe19c180f8373fa02ff00254d5394fec0349f5804e0ad2f6067854ff28ac",
     "vendor": "Igor Pavlov"
   },
   "7zip-extra.zip": {
     "name": "7zipextra",
     "description": "7Zip Extra: SFXs for installers",
-    "bundle": "no",
+    "bundle": "tools",
     "version": "9.20",
     "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/9.20/7z920_extra.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsevenzip%2Ffiles%2F7-Zip%2F9.20%2F",
     "filename": "7z920_extra.7z",
-    "sha256sum": "",
+    "sha256sum": "d65a1d1a050e4fd7912c18468954f64db824a1e1b621235a153d010beae14757",
     "vendor": "Igor Pavlov"
   }
 }


### PR DESCRIPTION
Replacement for #211 - with tools being downloaded to a separate folder to avoid them being bundled into the final archive.