### PR TITLE
JBDS-4002 OpenJDK detection does not work for build 1.8.0_101

### DIFF
--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -46,7 +46,7 @@ class JdkInstall extends InstallableItem {
   }
 
   detectExistingInstall(cb = new function(){}) {
-    let versionRegex = /version\s\"(\d+\.\d+\.\d+)_\d+\"/;
+    let versionRegex = /version\s\"(\d+\.\d+\.\d+)_.*\"/;
     let selectedFolder = '';
 
     let extension = '';


### PR DESCRIPTION
Fix contains new regex template to match previous and current formats