### PR TITLE
Make progress bars useful again

### DIFF
--- a/browser/directives/progressBar.js
+++ b/browser/directives/progressBar.js
@@ -27,7 +27,8 @@ function progressBar() {
               <div>{{productDesc}}</div>
             </div>
             <div class="progress progress-label-top-right">
-              <div class="progress-bar" role="progressbar" aria-valuenow="{{current}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}" style="width: {{current}}%;">
+              <div class="progress-bar" ng-class="{'progress-bar-striped active': status == 'Installing' || status == 'Setting up' || status.indexOf('Waiting') > -1}" role="progressbar" aria-valuenow="{{current}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}"
+                style="width: {{current}}%; animation: progress-bar-stripes 2s infinite steps(15);">
                 <span>{{label}}</span>
               </div>
             </div>

--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -52,11 +52,9 @@ class CDKInstall extends InstallableItem {
   downloadInstaller(progress, success, failure) {
     progress.setStatus('Downloading');
 
-    let downloadSize = 869598013;
-
     let totalDownloads = 3;
 
-    this.downloader = new Downloader(progress, success, failure, downloadSize, totalDownloads);
+    this.downloader = new Downloader(progress, success, failure, totalDownloads);
     let username = this.installerDataSvc.getUsername(),
         password = this.installerDataSvc.getPassword();
 

--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -114,8 +114,7 @@ class VagrantInstall extends InstallableItem {
     if(this.isDownloadRequired() && this.selectedOption === "install") {
       // Need to download the file
       let writeStream = fs.createWriteStream(this.downloadedFile);
-      let downloadSize = 199819264;
-      this.downloader = new Downloader(progress, success, failure, downloadSize);
+      this.downloader = new Downloader(progress, success, failure);
       this.downloader.setWriteStream(writeStream);
       this.downloader.download(this.downloadUrl,this.downloadedFile,this.sha256);
     } else {

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -158,7 +158,6 @@ class InstallerDataService {
     }
 
     this.startInstall(key);
-    progress.installTrigger();
 
     return item.install(progress,
       () => {


### PR DESCRIPTION
An attempt to make the progress bars more friendly than they appear to be now:
 - determinate progress only for downloads, now includes downloaded / total sizes
 - waiting and installing switches to animated indeterminate progress
 - failed components' progress bar turns red
 - completed progress bar turns green
 - restarting downloads resets the downloading progress

Comments, criticism, issues, etc. welcome