### PR TITLE
JBDS-4031 error sha check for downloaded cygwin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,6 +146,8 @@ gulp.task('create-7zip-archive', function(cb) {
   // only include prefetch folder when zipping if the folder exists and we're doing a bundle build
   if (fs.existsSync(path.resolve(prefetchFolder)) && installerExe.indexOf("-bundle") > 0) {
     packCmd = packCmd + ' ' + path.resolve(prefetchFolder) + path.sep + '*';
+  } else {
+      packCmd = packCmd + ' ' + path.resolve(prefetchFolder) + path.sep + 'cygwin.exe';
   }
   //console.log('[DEBUG]' + packCmd);
   exec(packCmd, createExecCallback(cb, true));
@@ -229,7 +231,7 @@ function createSHA256File(filename, cb) {
 // Create stub installer that will then download all the requirements
 gulp.task('package-simple', function(cb) {
   runSequence(['check-requirements', 'clean'], 'create-dist-win-dir', 'update-devstudio-version', ['generate',
-    'prepare-tools'], 'package', 'cleanup', cb);
+    'prepare-tools'], 'prefetch-cygwin', 'package', 'cleanup', cb);
 });
 
 gulp.task('package-bundle', function(cb) {
@@ -298,6 +300,11 @@ gulp.task('create-tools-dir',function() {
 // prefetch all the installer dependencies so we can package them up into the .exe
 gulp.task('prefetch', ['create-prefetch-cache-dir'], function() {
   return prefetch('yes', prefetchFolder);
+});
+
+// prefetch cygwin to always include into installer
+gulp.task('prefetch-cygwin', ['create-prefetch-cache-dir'], function() {
+  return prefetch('always', prefetchFolder);
 });
 
 gulp.task('prefetch-tools', ['create-tools-dir'], function() {

--- a/requirements.json
+++ b/requirements.json
@@ -36,7 +36,7 @@
   "cygwin.exe": {
     "name": "Cygwin",
     "description": "A distribution of popular GNU and other Open Source tools running on Microsoft Windows",
-    "bundle": "yes",
+    "bundle": "always",
     "version": "2.5.2",
     "url": "https://developers.redhat.com/redirect/to/cygwin-installer-2.5.2.download",
     "filename": "cygwin_2.5.2.exe",


### PR DESCRIPTION
Always include cygwin.exe in installer for one big reason. If file gets updated to new one, there is no archived copy of previous one and that means redirect we use does not help.
