### PR TITLE
JBDS-4043 Update cygwin version to 2.6.0

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -37,9 +37,9 @@
     "name": "Cygwin",
     "description": "A distribution of popular GNU and other Open Source tools running on Microsoft Windows",
     "bundle": "always",
-    "version": "2.5.2",
-    "url": "https://developers.redhat.com/redirect/to/cygwin-installer-2.5.2.download",
-    "filename": "cygwin_2.5.2.exe",
+    "version": "2.6.0",
+    "url": "https://cygwin.com/setup-x86_64.exe",
+    "filename": "cygwin_2.6.0.exe",
     "sha256sum": "58f9f42f5dbd52c5e3ecd24e537603ee8897ea15176b7acdc34afcef83e5c19a",
     "virusTotalReport": "https://virustotal.com/en/file/58f9f42f5dbd52c5e3ecd24e537603ee8897ea15176b7acdc34afcef83e5c19a/analysis/",
     "vendor": "Community Project"


### PR DESCRIPTION
Fix updates version shown in installer to 2.6.0 and place direct link
instead of redirect because cygwin installer (size under 1M) will be
always included in online and bunded installer after
https://issues.jboss.org/browse/JBDS-4031 is fixed

It means it is  going to be alway downloaded during the build.