### PR TITLE
JBDS-4007 Need a new check for existing OpenJDK installed as MSI

### DIFF
--- a/browser/model/helpers/util.js
+++ b/browser/model/helpers/util.js
@@ -21,7 +21,7 @@ class Util {
     });
   }
 
-  static executeFile(file, args, outputCode) {
+  static executeFile(file, args, outputCode=1) {
     return new Promise((resolve, reject) => {
       child_process.execFile(file, args, (error, stdout, stderr) => {
         if (error) {
@@ -34,6 +34,18 @@ class Util {
           }
         }
       })
+    });
+  }
+
+  static writeFile(key, file, data) {
+    return new Promise((resolve, reject) => {
+      fs.writeFile(file, data, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(true);
+        }
+      });
     });
   }
 

--- a/browser/pages/confirm/confirm.html
+++ b/browser/pages/confirm/confirm.html
@@ -362,7 +362,7 @@
            ng-class="{'dotted-panel':checkboxModel.jdk.hasOption('detected')&&checkboxModel.jdk.selectedOption === 'detected'}">
            <!--ng-click="checkboxModel.jdk.changeIsCollapsed()">-->
            <div class="checkbox-container verticalLine">
-             <input type="checkbox" ng-disabled="!checkboxModel.jdk.hasOption('detected') && checkboxModel.jbds.selectedOption === 'install' || checkboxModel.jdk.hasOption('detected') && !checkboxModel.jdk.option.detected.valid && checkboxModel.jbds.selectedOption === 'install'" ng-model="checkboxModel.jdk.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
+             <input type="checkbox" ng-disabled="!checkboxModel.jdk.hasOption('detected') && checkboxModel.jbds.selectedOption === 'install' || checkboxModel.jdk.hasOption('detected') && !checkboxModel.jdk.option.detected.valid && checkboxModel.jbds.selectedOption === 'install' || checkboxModel.jdk.hasOption('detected') && checkboxModel.jdk.option.detected.valid && checkboxModel.jdk.openJdkMsi" ng-model="checkboxModel.jdk.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
            </div>
         <div class="checkbox-container" ng-show="false">
           <div id="arrow-jdk" class="arrow" ng-class="{'arrow-down':!checkboxModel.jdk.isCollapsed}" aria-label="Toggle ngHide"></div>
@@ -520,7 +520,8 @@
   <button type="button" id="confirm-cancel-btn" class="cancel-btn footer-btns btn-plain btn-med-size btn btn-lg pull-left" form="confirmForm"
           ng-click="confCtrl.exit()">Cancel</button>
   <button type="button" id="confirm-back-btn" class="back-btn-spacer footer-btns btn-plain btn-med-size btn btn-lg" form="confirmForm"
+          ng-disabled="confCtrl.isDisabled"
           ng-click="confCtrl.back()">Back</button>
   <button type="submit" id="confirm-install-btn" class="go-btn footer-btns btn btn-primary btn-lg" form="confirmForm"
-          ng-disabled="!confCtrl.isConfigurationValid()" autofocus>Download & Install</button>
+          ng-disabled="!confCtrl.isConfigurationValid() || confCtrl.isDisabled" autofocus>Download & Install</button>
 </footer>


### PR DESCRIPTION
Fix implements:
1. Check if OpenJDK MSI package installed, using the same query
   used by uninstall.ps1. It sets flag openJdkMsi on JdkInstall
   instance. This flag blocks OpenJDK selection for installation
   to avoid possible installation errors in case msi cannot update
   already installed OpenJDK;
2. Disabling for Back ad Next buttons on Confirmation page until
   detection is finished.