### PR TITLE
JBDS-4048 OpenJDK detection stuck

### DIFF
--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -66,9 +66,11 @@ class JdkInstall extends InstallableItem {
 
     let data = [
       "$vbox = Get-WmiObject Win32_Product | where {$_.Name -like '*OpenJDK*'};",
-      "echo $vbox.IdentifyingNumber"
+      "echo $vbox.IdentifyingNumber;",
+      "[Environment]::Exit(0);"
     ].join('\r\n');
     let args = [
+      '-NonInteractive',
       '-ExecutionPolicy',
       'ByPass',
       '-File',


### PR DESCRIPTION
Fix adds to the powershell execution:
* -Noneinteractive option;
* exit(0) call in the end of the script