### PR TITLE
JBDS-4047 uninstaller does not clean up path

### DIFF
--- a/uninstaller/uninstall.ps1
+++ b/uninstaller/uninstall.ps1
@@ -50,8 +50,10 @@ echo 'Removing path entries'
 [string[]] $pathFolders = [Environment]::GetEnvironmentVariable("Path", "User") -Split ';'
 [Collections.ArrayList] $folderList = New-Object Collections.Arraylist
 
+$targetFolder = [System.IO.Path]::GetFullPath((Join-Path ($folder) '..'))
+
 $pathFolders | foreach {
-  If (-Not ($_ -like "$folder*")) {
+  If (-Not ($_ -like "$targetFolder*")) {
     $folderList.Add($_) | Out-Null
   }
 }


### PR DESCRIPTION
Fix corrects target folder path being used for
filtering Path variable entries. It changes root folder
to be one level up from uninstaller folder.