### PR TITLE
Update hardcoded dist/win folder to be based on current platform/arch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,12 +27,11 @@ var gulp = require('gulp'),
 require('./gulp-tasks/tests')(gulp);
 
 var artifactName = 'devsuite',
-    artifactPlatform = 'win32',
-    artifactArch = 'x64';
+    artifactPlatform = process.platform,
+    artifactArch = process.arch;
 
-var buildFolderRoot = 'dist/win/';
-var buildFileNamePrefix = artifactName + '-' + artifactPlatform + '-' + artifactArch;
-var buildFolder = buildFolderRoot + buildFileNamePrefix;
+var buildFolderRoot = path.join('dist', artifactPlatform + '-' + artifactArch );
+var buildFileNamePrefix = artifactName;
 // use folder outside buildFolder so that a 'clean' task won't wipe out the cache
 var prefetchFolder = 'requirements-cache';
 let toolsFolder = 'tools';

--- a/protractor-conf.js
+++ b/protractor-conf.js
@@ -1,5 +1,6 @@
 var files;
 var report;
+var platform =  process.platform + '-' + process.arch;
 
 if (process.env.PTOR_TEST_RUN === 'system') {
   files = ['test/system/*.js'];
@@ -20,7 +21,7 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
-      binary: './dist/win/devsuite-win32-x64/devsuite.exe'
+      binary: './dist/' + platform +'/devsuite-' + platform + '/devsuite.exe'
     }
   },
 


### PR DESCRIPTION
Fix removes unused local var and updates rootbuildfolder to be
named after current platform-arch, rather than hardcoded to
dist/win. Tis fix after merge will require to update nightly
build publishing config on central CI.