### PR TITLE
JBDS-4083 update devstudio installer start to support all platforms

### DIFF
--- a/browser/model/jbds.js
+++ b/browser/model/jbds.js
@@ -1,4 +1,4 @@
-'use strict';
+  'use strict';
 
 let request = require('request');
 let path = require('path');
@@ -215,10 +215,7 @@ class JbdsInstall extends InstallableItem {
       if (!jdk.hasExistingInstall()) {
         Logger.info(JbdsInstall.key() + ' - Configure -vm parameter to ' + this.installerDataSvc.jdkRoot);
         let config = path.join(this.existingInstallLocation, 'studio', 'devstudio.ini');
-        let javaExecutable = path.join(this.installerDataSvc.jdkRoot, 'bin', 'java');
-        if (process.platform === 'win32') {
-          javaExecutable += 'w.exe';
-        }
+        let javaExecutable = path.join(this.installerDataSvc.jdkRoot, 'bin', 'javaw');
 
         replace({
           files: config,
@@ -271,7 +268,7 @@ class JbdsInstall extends InstallableItem {
       this.downloadedFile,
       this.installConfigFile
     ];
-    let res = installer.execFile(path.join(this.installerDataSvc.jdkDir(), 'bin', 'java.exe'), javaOpts)
+    let res = installer.execFile(path.join(this.installerDataSvc.jdkDir(), 'bin', 'java'), javaOpts)
       .then((result) => { return this.setupCdk(result);});
 
     return res;

--- a/test/unit/model/jbds-test.js
+++ b/test/unit/model/jbds-test.js
@@ -178,7 +178,7 @@ describe('devstudio installer', function() {
       item2.setInstallComplete();
       item2.thenInstall(installer);
       installer.install(fakeProgress, () => {}, (err) => {});
-      
+
       expect(stub).calledOnce;
     });
 
@@ -263,7 +263,7 @@ describe('devstudio installer', function() {
       it('should perform headless install into the installation folder', function() {
         let spy = sandbox.spy(helper, 'execFile');
 
-        let javaPath = path.join(installerDataSvc.jdkDir(), 'bin', 'java.exe');
+        let javaPath = path.join(installerDataSvc.jdkDir(), 'bin', 'java');
         let javaOpts = [
           '-DTRACE=true',
           '-jar',


### PR DESCRIPTION
Use java (no extension) on all platforms and let windows find .exe
file.