### PR TITLE
JBDS-4080  Avoid to redownload everything on each install

### DIFF
--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let fs = require('fs');
+let fs = require('fs-extra');
 let request = require('request');
 let path = require('path');
 
@@ -19,7 +19,8 @@ class CygwinInstall extends InstallableItem {
           downloadUrl,
           installFile,
           targetFolderName,
-          installerDataSvc);
+          installerDataSvc,
+          false);
 
     this.downloadedFileName = 'cygwin.exe';
     this.bundledFile = path.join(this.downloadFolder, this.downloadedFileName);
@@ -55,21 +56,6 @@ class CygwinInstall extends InstallableItem {
         this.addOption('different','','',false);
         cb(error);
       });
-  }
-
-  downloadInstaller(progress, success, failure) {
-    progress.setStatus('Downloading');
-
-    if(!fs.existsSync(this.bundledFile)) {
-      // Need to download the file
-      let writeStream = fs.createWriteStream(this.downloadedFile);
-      this.downloader = new Downloader(progress, success, failure);
-      this.downloader.setWriteStream(writeStream);
-      this.downloader.download(this.downloadUrl,this.downloadedFile,this.checksum);
-    } else {
-      this.downloadedFile = this.bundledFile;
-      success();
-    }
   }
 
   install(progress, success, failure) {

--- a/browser/model/jbds.js
+++ b/browser/model/jbds.js
@@ -2,7 +2,7 @@
 
 let request = require('request');
 let path = require('path');
-let fs = require('fs');
+let fs = require('fs-extra');
 let Glob = require("glob").Glob;
 let replace = require("replace-in-file");
 
@@ -22,7 +22,8 @@ class JbdsInstall extends InstallableItem {
           downloadUrl,
           installFile,
           targetFolderName,
-          installerDataSvc);
+          installerDataSvc,
+          true);
 
     this.downloadedFileName = 'jbds.jar';
     this.jbdsSha256 = jbdsSha256;
@@ -112,22 +113,6 @@ class JbdsInstall extends InstallableItem {
       }
       this.ipcRenderer.send('checkComplete', JbdsInstall.key());
     });
-  }
-
-  downloadInstaller(progress, success, failure) {
-    let username = this.installerDataSvc.getUsername(),
-        password = this.installerDataSvc.getPassword();
-    progress.setStatus('Downloading');
-    if(!this.hasExistingInstall() && !fs.existsSync(this.bundledFile)) {
-      // Need to download the file
-      let writeStream = fs.createWriteStream(this.downloadedFile);
-      this.downloader = new Downloader(progress, success, failure);
-      this.downloader.setWriteStream(writeStream);
-      this.downloader.downloadAuth(this.downloadUrl,username,password,this.downloadedFile,this.jbdsSha256);
-    } else {
-      this.downloadedFile = this.bundledFile;
-      success();
-    }
   }
 
   install(progress, success, failure) {

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let fs = require('fs');
+let fs = require('fs-extra');
 let path = require('path');
 var rimraf = require('rimraf');
 
@@ -20,7 +20,8 @@ class JdkInstall extends InstallableItem {
           downloadUrl,
           installFile,
           targetFolderName,
-          installerDataSvc);
+          installerDataSvc,
+          true);
 
     this.downloadedFileName = 'jdk.msi';
     this.jdkSha256 = jdkSha256;
@@ -130,22 +131,6 @@ class JdkInstall extends InstallableItem {
 
   static key() {
     return 'jdk';
-  }
-
-  downloadInstaller(progress, success, failure) {
-    let username = this.installerDataSvc.getUsername(),
-        password = this.installerDataSvc.getPassword();
-    progress.setStatus('Downloading');
-    if(this.selectedOption == 'install' && !fs.existsSync(this.bundledFile)) {
-      // Need to download the file
-      let writeStream = fs.createWriteStream(this.downloadedFile);
-      this.downloader = new Downloader(progress, success, failure);
-      this.downloader.setWriteStream(writeStream);
-      this.downloader.downloadAuth(this.downloadUrl,username,password,this.downloadedFile,this.jdkSha256);
-    } else {
-      this.downloadedFile = this.bundledFile;
-      success();
-    }
   }
 
   install(progress, success, failure) {

--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -18,7 +18,8 @@ class VagrantInstall extends InstallableItem {
           downloadUrl,
           installFile,
           targetFolderName,
-          installerDataSvc);
+          installerDataSvc,
+          false);
 
     this.downloadedFileName = 'vagrant.msi';
     this.bundledFile = path.join(this.downloadFolder, this.downloadedFileName);
@@ -106,20 +107,6 @@ class VagrantInstall extends InstallableItem {
 
   isDownloadRequired() {
     return !this.hasExistingInstall() && !fs.existsSync(this.bundledFile);
-  }
-
-  downloadInstaller(progress, success, failure) {
-    progress.setStatus('Downloading');
-    if(this.isDownloadRequired() && this.selectedOption === "install") {
-      // Need to download the file
-      let writeStream = fs.createWriteStream(this.downloadedFile);
-      this.downloader = new Downloader(progress, success, failure);
-      this.downloader.setWriteStream(writeStream);
-      this.downloader.download(this.downloadUrl,this.downloadedFile,this.sha256);
-    } else {
-      this.downloadedFile = this.bundledFile;
-      success();
-    }
   }
 
   install(progress, success, failure) {

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let fs = require('fs');
+let fs = require('fs-extra');
 let path = require('path');
 
 import InstallableItem from './installable-item';
@@ -17,7 +17,8 @@ class VirtualBoxInstall extends InstallableItem {
           downloadUrl,
           installFile,
           targetFolderName,
-          installerDataSvc);
+          installerDataSvc,
+          false);
 
     this.minimumVersion = '5.0.26';
     this.version = version || '5.0.26';
@@ -138,19 +139,6 @@ class VirtualBoxInstall extends InstallableItem {
 
   isDownloadRequired() {
     return !this.hasExistingInstall() && !fs.existsSync(this.bundledFile);
-  }
-
-  downloadInstaller(progress, success, failure) {
-    progress.setStatus('Downloading');
-    if(this.isDownloadRequired() && this.selectedOption === "install") {
-      let writeStream = fs.createWriteStream(this.downloadedFile);
-      this.downloader = new Downloader(progress, success, failure);
-      this.downloader.setWriteStream(writeStream);
-      this.downloader.download(this.downloadUrl,this.downloadedFile,this.sha256);
-    } else {
-      this.downloadedFile = this.bundledFile;
-      success();
-    }
   }
 
   install(progress, success, failure) {

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -12,6 +12,7 @@ import VirtualboxInstall from "browser/model/virtualbox";
 import Logger from 'browser/services/logger';
 import Downloader from 'browser/model/helpers/downloader';
 import Installer from 'browser/model/helpers/installer';
+import Hash from 'browser/model/helpers/hash';
 import InstallableItem from 'browser/model/installable-item';
 import InstallerDataService from 'browser/services/data';
 import chaiAsPromised from 'chai-as-promised';
@@ -24,7 +25,7 @@ require('sinon-as-promised');
 
 describe('CDK installer', function() {
   let sandbox, installerDataSvc;
-  let infoStub, errorStub;
+  let infoStub, errorStub, sha256Stub;
 
   let fakeProgress = {
     setStatus: function (desc) { return; },
@@ -59,6 +60,7 @@ describe('CDK installer', function() {
   before(function() {
     infoStub = sinon.stub(Logger, 'info');
     errorStub = sinon.stub(Logger, 'error');
+    sha256Stub = sinon.stub(Hash.prototype,'SHA256', function(file,cb) {cb("hash");});
 
     mockfs({
       temporaryFolder: {},
@@ -79,6 +81,7 @@ describe('CDK installer', function() {
     mockfs.restore();
     infoStub.restore();
     errorStub.restore();
+    sha256Stub.restore();
   });
 
   let reqs = require(path.resolve('./requirements.json'));

--- a/test/unit/model/cygwin-test.js
+++ b/test/unit/model/cygwin-test.js
@@ -5,12 +5,13 @@ import sinon from 'sinon';
 import { default as sinonChai } from 'sinon-chai';
 import mockfs from 'mock-fs';
 import request from 'request';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import CygwinInstall from 'browser/model/cygwin';
 import Logger from 'browser/services/logger';
 import Downloader from 'browser/model/helpers/downloader';
 import Installer from 'browser/model/helpers/installer';
+import Hash from 'browser/model/helpers/hash';
 import InstallableItem from 'browser/model/installable-item';
 import InstallerDataService from 'browser/services/data';
 import child_process from 'child_process';
@@ -18,7 +19,7 @@ chai.use(sinonChai);
 
 describe('Cygwin installer', function() {
   let installerDataSvc, sandbox, installer;
-  let infoStub, errorStub;
+  let infoStub, errorStub, sha256Stub;
   let downloadUrl = 'https://cygwin.com/setup-x86_64.exe';
   let fakeInstallable = {
     isInstalled: function() { return false; }
@@ -47,6 +48,9 @@ describe('Cygwin installer', function() {
   before(function() {
     infoStub = sinon.stub(Logger, 'info');
     errorStub = sinon.stub(Logger, 'error');
+    sha256Stub = sinon.stub(Hash.prototype,'SHA256', function(file,cb) {
+      cb("hash");
+    });
 
     mockfs({
       tempDirectory: {},
@@ -61,6 +65,7 @@ describe('Cygwin installer', function() {
     mockfs.restore();
     infoStub.restore();
     errorStub.restore();
+    sha256Stub.restore();
   });
 
   beforeEach(function () {

--- a/test/unit/model/installable-item-test.js
+++ b/test/unit/model/installable-item-test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import { default as sinonChai } from 'sinon-chai';
 import mockfs from 'mock-fs';
 import request from 'request';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import InstallableItem from 'browser/model/installable-item';
 import Logger from 'browser/services/logger';
@@ -13,31 +13,149 @@ import Downloader from 'browser/model/helpers/downloader';
 import Installer from 'browser/model/helpers/installer';
 import child_process from 'child_process';
 import InstallerDataService from 'browser/services/data';
+import Hash from 'browser/model/helpers/hash';
 
 chai.use(sinonChai);
 
-describe('Installable Item', function() {
+describe('InstallableItem', function() {
 
-  it('should return passed parameter for thenInstall call', function() {
-    let svc = new InstallerDataService();
-    let item1 = new InstallableItem('jdk', 1000, 'url', 'installFile', 'targetFolderName', svc);
-    let item2 = new InstallableItem('cygwin', 1000, 'url', 'installFile', 'targetFolderName', svc);
-    item1.thenInstall(item2);
-    expect(item2.installAfter).to.be.equal(item1);
-    expect(item2.getInstallAfter()).to.be.equal(item1);
+  let infoStub;
+  before(function(){
+    infoStub = sinon.stub(Logger, 'info');
   });
 
-
-  it('should ignore skipped installers and return first selected for installation', function() {
-    let svc = new InstallerDataService();
-    let item1 = new InstallableItem('jdk', 1000, 'url', 'installFile', 'targetFolderName', svc);
-    let item2 = new InstallableItem('cygwin', 1000, 'url', 'installFile', 'targetFolderName', svc);
-    item2.selectedOption = 'detected';
-    let item3 = new InstallableItem('jbds', 1000, 'url', 'installFile', 'targetFolderName', svc);
-    item3.selectedOption = 'detected';
-    let item4 = new InstallableItem('cdk', 1000, 'url', 'installFile', 'targetFolderName', svc);
-    svc.addItemsToInstall(item1,item2,item3,item4);
-    item1.thenInstall(item2).thenInstall(item3).thenInstall(item4);
-    expect(item4.getInstallAfter()).to.be.equal(item1);
+  after(function(){
+    infoStub.restore();
   });
+
+  let sandbox;
+  beforeEach(function(){
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function(){
+    sandbox.restore();
+  });
+
+  describe('thenInstall method', function() {
+
+    it('should return passed parameter', function() {
+      let svc = new InstallerDataService();
+      let item1 = new InstallableItem('jdk', 1000, 'url', 'installFile', 'targetFolderName', svc);
+      let item2 = new InstallableItem('cygwin', 1000, 'url', 'installFile', 'targetFolderName', svc);
+      item1.thenInstall(item2);
+      expect(item2.installAfter).to.be.equal(item1);
+      expect(item2.getInstallAfter()).to.be.equal(item1);
+    });
+
+  });
+
+  describe('getInstallAfter method', function() {
+
+    it('should ignore skipped installers and return first selected for installation', function() {
+      let svc = new InstallerDataService();
+      let item1 = new InstallableItem('jdk', 1000, 'url', 'installFile', 'targetFolderName', svc);
+      let item2 = new InstallableItem('cygwin', 1000, 'url', 'installFile', 'targetFolderName', svc);
+      item2.selectedOption = 'detected';
+      let item3 = new InstallableItem('jbds', 1000, 'url', 'installFile', 'targetFolderName', svc);
+      item3.selectedOption = 'detected';
+      let item4 = new InstallableItem('cdk', 1000, 'url', 'installFile', 'targetFolderName', svc);
+      svc.addItemsToInstall(item1,item2,item3,item4);
+      item1.thenInstall(item2).thenInstall(item3).thenInstall(item4);
+      expect(item4.getInstallAfter()).to.be.equal(item1);
+    });
+
+  });
+
+  describe('checkAndDownload method', function() {
+    let svc, downloader, installItem;
+
+    beforeEach(function(){
+      svc = new InstallerDataService();
+      downloader = new Downloader(null,function(){});
+      installItem = new InstallableItem('jdk', 5000, 'downloadUrl', null, 'targetLocation', svc, false);
+      installItem.downloader = downloader;
+    });
+
+
+    it('shoudld return loacation for bundled file if present',function() {
+      sandbox.stub(fs,'existsSync').returns(true);
+
+      let location = installItem.checkAndDownload('bundled.zip','does-not-matter','url','sha');
+
+      expect(location).to.be.equal('bundled.zip');
+    });
+
+    it('shoudld return temporary file location if bundled file is not present',function() {
+      sandbox.stub(fs,'existsSync').returns(false);
+      sandbox.stub(installItem,'startDownload').returns(false);
+
+      let location = installItem.checkAndDownload('bundled.zip','temp/inatall.zip','url','sha');
+
+      expect(location).to.be.equal('temp/inatall.zip');
+    });
+
+    it('should start to download file if there is no bundled and no dowloaded file',function() {
+      sandbox.stub(fs,'existsSync').returns(false);
+      let startDlMock = sandbox.stub(installItem,'startDownload').returns();
+
+      let location = installItem.checkAndDownload('bundled.zip','temp/inatall.zip','url','sha');
+
+      expect(startDlMock).to.have.been.calledOnce;
+    });
+
+    it('should start download file if there is no bundled and there is dowloaded file with wrong checksum',function() {
+      sandbox.stub(fs,'existsSync').onCall(0).returns(false).onCall(1).returns(true);
+      let startDlMock = sandbox.stub(installItem,'startDownload').returns();
+      sandbox.stub(Hash.prototype,'SHA256').yields('wrongsha');
+
+      let location = installItem.checkAndDownload('bundled.zip','temp/inatall.zip','url','sha');
+
+      expect(startDlMock).to.have.been.calledOnce;
+    });
+
+    it('should not start download file if there is no bundled and there is dowloaded file with correct checksum',function() {
+      let successHandStub = sandbox.stub(downloader,'successHandler').returns();
+      sandbox.stub(fs,'existsSync').onCall(0).returns(false).onCall(1).returns(true);
+      let startDlMock = sandbox.stub(installItem,'startDownload').returns();
+      sandbox.stub(Hash.prototype,'SHA256').yields('sha');
+
+      let location = installItem.checkAndDownload('bundled.zip','temp/inatall.zip','url','sha');
+
+      expect(successHandStub).to.have.been.calledOnce;
+    });
+
+  });
+
+  describe('startDownload method', function() {
+    let svc, installItem;
+
+    beforeEach(function(){
+      svc = new InstallerDataService();
+      installItem = new InstallableItem('jdk', 5000, 'downloadUrl', null, 'targetLocation', svc, false);
+      installItem.downloader = new Downloader(null,function(){});
+    });
+
+    it('should start download w/o auth if no username and password provided',function(){
+      let setWriteStreamStub = sinon.mock(installItem.downloader).expects('setWriteStream').once(),
+        downloadStub = sinon.mock(installItem.downloader).expects('download').once().withArgs('url','downloadto.zip','sha');
+
+      let location = installItem.startDownload('downloadto.zip','url','sha');
+
+      setWriteStreamStub.verify();
+      downloadStub.verify();
+    });
+
+    it('should start download w/ auth if username and password provided',function(){
+      let setWriteStreamStub = sinon.mock(installItem.downloader).expects('setWriteStream').once(),
+        downloadStub = sinon.mock(installItem.downloader).expects('downloadAuth').once().withArgs('url','user','password','downloadto.zip','sha');
+
+      let location = installItem.startDownload('downloadto.zip','url','sha','user','password');
+
+      setWriteStreamStub.verify();
+      downloadStub.verify();
+    });
+
+  });
+
 });

--- a/test/unit/model/jbds-test.js
+++ b/test/unit/model/jbds-test.js
@@ -4,13 +4,14 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import { default as sinonChai } from 'sinon-chai';
 import mockfs from 'mock-fs';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import JbdsInstall from 'browser/model/jbds';
 import JdkInstall from 'browser/model/jdk-install';
 import Logger from 'browser/services/logger';
 import Downloader from 'browser/model/helpers/downloader';
 import Installer from 'browser/model/helpers/installer';
+import Hash from 'browser/model/helpers/hash';
 import InstallableItem from 'browser/model/installable-item';
 import JbdsAutoInstallGenerator from 'browser/model/jbds-autoinstall';
 import InstallerDataService from 'browser/services/data';
@@ -18,7 +19,7 @@ chai.use(sinonChai);
 
 describe('devstudio installer', function() {
   let installerDataSvc;
-  let infoStub, errorStub, sandbox, installer;
+  let infoStub, errorStub, sandbox, installer, sha256Stub;
   let downloadUrl = 'https://devstudio.redhat.com/9.0/snapshots/builds/devstudio.product_9.0.mars/latest/all/jboss-devstudio-9.1.0.latest-installer-standalone.jar';
   let fakeInstall = {
     isInstalled: function() { return false; }
@@ -49,6 +50,7 @@ describe('devstudio installer', function() {
   before(function() {
     infoStub = sinon.stub(Logger, 'info');
     errorStub = sinon.stub(Logger, 'error');
+    sha256Stub = sinon.stub(Hash.prototype,'SHA256', function(file,cb) {cb("hash");});
 
     mockfs({
       tempDirectory : { 'testFile': 'file content here' },
@@ -63,6 +65,7 @@ describe('devstudio installer', function() {
     mockfs.restore();
     infoStub.restore();
     errorStub.restore();
+    sha256Stub.restore();
   });
 
   beforeEach(function () {

--- a/test/unit/model/jdk-install-test.js
+++ b/test/unit/model/jdk-install-test.js
@@ -5,12 +5,13 @@ import sinon from 'sinon';
 import { default as sinonChai } from 'sinon-chai';
 import mockfs from 'mock-fs';
 import request from 'request';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import JdkInstall from 'browser/model/jdk-install';
 import Logger from 'browser/services/logger';
 import Downloader from 'browser/model/helpers/downloader';
 import Installer from 'browser/model/helpers/installer';
+import Hash from 'browser/model/helpers/hash';
 import InstallableItem from 'browser/model/installable-item';
 import IinstallerDataService from 'browser/services/data';
 import rimraf from 'rimraf';
@@ -18,7 +19,7 @@ chai.use(sinonChai);
 
 describe('JDK installer', function() {
   let installerDataSvc, sandbox, installer;
-  let infoStub, errorStub;
+  let infoStub, errorStub, sha256Stub;
   let downloadUrl = 'http://www.azulsystems.com/products/zulu/downloads';
   let fakeInstallable = {
     isInstalled: function() { return true; }
@@ -46,6 +47,7 @@ describe('JDK installer', function() {
   before(function() {
     infoStub = sinon.stub(Logger, 'info');
     errorStub = sinon.stub(Logger, 'error');
+    sha256Stub = sinon.stub(Hash.prototype,'SHA256', function(file,cb) {cb("hash");});
 
     mockfs({
       'tempDirectory' : {
@@ -65,6 +67,7 @@ describe('JDK installer', function() {
     mockfs.restore();
     infoStub.restore();
     errorStub.restore();
+    sha256Stub.restore();
   });
 
   beforeEach(function () {

--- a/test/unit/model/vagrant-test.js
+++ b/test/unit/model/vagrant-test.js
@@ -11,6 +11,7 @@ import VagrantInstall from 'browser/model/vagrant';
 import Logger from 'browser/services/logger';
 import Downloader from 'browser/model/helpers/downloader';
 import Installer from 'browser/model/helpers/installer';
+import Hash from 'browser/model/helpers/hash';
 import InstallableItem from 'browser/model/installable-item';
 import Util from 'browser/model/helpers/util';
 import InstallerDataService from 'browser/services/data';
@@ -21,7 +22,7 @@ describe('Vagrant installer', function() {
   let installer;
   let downloadUrl = 'https://github.com/redhat-developer-tooling/vagrant-distribution/archive/1.7.4.zip';
   let installerDataSvc;
-  let infoStub, errorStub, sandbox;
+  let infoStub, errorStub, sandbox, sha256Stub;
   let fakeInstallable = {
     isInstalled: function() { return false; }
   };
@@ -48,6 +49,7 @@ describe('Vagrant installer', function() {
   before(function() {
     infoStub = sinon.stub(Logger, 'info');
     errorStub = sinon.stub(Logger, 'error');
+    sha256Stub = sinon.stub(Hash.prototype,'SHA256', function(file,cb) {cb("hash");});
 
     mockfs({
       'tempDirectory' : {},
@@ -62,6 +64,7 @@ describe('Vagrant installer', function() {
     mockfs.restore();
     infoStub.restore();
     errorStub.restore();
+    sha256Stub.restore();
   });
 
   beforeEach(function () {

--- a/test/unit/model/virtualbox-test.js
+++ b/test/unit/model/virtualbox-test.js
@@ -5,12 +5,13 @@ import sinon from 'sinon';
 import { default as sinonChai } from 'sinon-chai';
 import mockfs from 'mock-fs';
 import request from 'request';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import VirtualBoxInstall from 'browser/model/virtualbox';
 import Logger from 'browser/services/logger';
 import Downloader from 'browser/model/helpers/downloader';
 import Installer from 'browser/model/helpers/installer';
+import Hash from 'browser/model/helpers/hash';
 import InstallableItem from 'browser/model/installable-item';
 import Util from 'browser/model/helpers/util';
 import InstallerDataService from 'browser/services/data'
@@ -20,7 +21,7 @@ let child_process = require('child_process');
 
 describe('Virtualbox installer', function() {
   let installerDataSvc, installer;
-  let infoStub, errorStub, sandbox;
+  let infoStub, errorStub, sandbox, sha256Stub;
 
   let downloadUrl = 'http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}-${revision}-Win.exe',
       version = '5.0.26',
@@ -48,6 +49,7 @@ describe('Virtualbox installer', function() {
   before(function() {
     infoStub = sinon.stub(Logger, 'info');
     errorStub = sinon.stub(Logger, 'error');
+    sha256Stub = sinon.stub(Hash.prototype,'SHA256', function(file,cb) {cb("hash");});
 
     mockfs({
       tempDirectory: {},
@@ -62,6 +64,7 @@ describe('Virtualbox installer', function() {
     mockfs.restore();
     infoStub.restore();
     errorStub.restore();
+    sha256Stub.restore();
   });
 
   beforeEach(function () {


### PR DESCRIPTION
Fix adds verification for downloaded files in temp folder and
if sha is the same installer uses those files instead of downloading
them again.