### PR TITLE
JBDS-4120 CDK Installer does not work on Mac OS X

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -130,9 +130,9 @@ class CDKInstall extends InstallableItem {
     installer.unzip(this.cdkDownloadedFile, this.installerDataSvc.installDir())
     .then((result) => { return installer.unzip(this.ocDownloadedFile, this.installerDataSvc.ocDir(), result); })
     .then((result) => { return installer.copyFile(this.cdkBoxDownloadedFile, path.join(this.installerDataSvc.cdkBoxDir(), this.boxName), result); })
-    .then((result) => { return installer.writeFile(this.pscpPathScript, data, result); })
+    .then((result) => { return process.platform === 'win32' ? installer.writeFile(this.pscpPathScript, data, result) : Promise.resolve(true); })
     .then((result) => { return installer.writeFile(this.installerDataSvc.cdkMarker(), markerContent, result); })
-    .then((result) => { return installer.execFile('powershell', opts, result); })
+    .then((result) => { return process.platform === 'win32' ?  installer.execFile('powershell', opts, result) : Promise.resolve(true); })
     .then((result) => { return this.setupVagrant(installer, result); })
     .then((result) => { return installer.succeed(result); })
     .catch((error) => { return installer.fail(error); });


### PR DESCRIPTION
Fix skips windows specific code to let CDK installer
finish installation without configuring PATH env variable.