### PR TITLE
JBDS-4138 Remove setx VAGRANT_DETECTED_OS setup from vagrant installer

### DIFF
--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -156,8 +156,6 @@ class VagrantInstall extends InstallableItem {
     .then((result) => {
       return installer.execFile('powershell', args, result);
     }).then((result) => {
-      return installer.exec('setx VAGRANT_DETECTED_OS "cygwin"');
-    }).then((result) => {
       return installer.succeed(true);
     }).catch((result) => {
       return installer.fail(result);


### PR DESCRIPTION
Fix remoses execution setx from vagrant.js, because it is CDK
responsibility to set it up.