### PR TITLE
JBDS-4139 undefined key used in cdk whenlogging PATH env var value

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -166,7 +166,7 @@ class CDKInstall extends InstallableItem {
       + path.delimiter + path.join(vgrPath,'bin')
       + path.delimiter + path.join(cygwinPath,'bin')
       + path.delimiter + vboxPath;
-    Logger.info(this.key + ' - Set PATH environment variable to \'' + env['Path'] + '\'');
+    Logger.info(CDKInstall.key() + ' - Set PATH environment variable to \'' + env['Path'] + '\'');
     return env;
   }
 


### PR DESCRIPTION
Fix updates the code to use static method to get the key instead of this.key.