### PR TITLE
JBDS-4140 env['Path'] doesn't work for child_process on OS X

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -162,11 +162,11 @@ class CDKInstall extends InstallableItem {
     let vgrPath = vagrantInstall.getLocation();
     let vboxPath = vboxInstall.getLocation();
     let cygwinPath = cygwinInstall.getLocation();
-    env['Path'] = env['Path']
+    env['PATH'] = env['PATH']
       + path.delimiter + path.join(vgrPath,'bin')
       + path.delimiter + path.join(cygwinPath,'bin')
       + path.delimiter + vboxPath;
-    Logger.info(CDKInstall.key() + ' - Set PATH environment variable to \'' + env['Path'] + '\'');
+    Logger.info(CDKInstall.key() + ' - Set PATH environment variable to \'' + env['PATH'] + '\'');
     return env;
   }
 

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -225,7 +225,7 @@ describe('CDK installer', function() {
     describe('createEnvironment', function() {
       it('should return path with vagrant/bin', function() {
         let env = installer.createEnvironment();
-        expect(env['Path']).includes(path.join(installerDataSvc.vagrantDir(), 'bin') + path.delimiter + installerDataSvc.vagrantDir());
+        expect(env['PATH']).includes(path.join(installerDataSvc.vagrantDir(), 'bin') + path.delimiter + installerDataSvc.vagrantDir());
       });
     });
 


### PR DESCRIPTION
Fix updates name to 'PATH" because it works for OS X and Window