### PR TITLE
JBDS-4161 VAGRANT_HOME is not set for vagrant plugin installation

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -156,9 +156,9 @@ class CDKInstall extends InstallableItem {
       vgrPath = vagrantInstall.getLocation(),
       vboxPath = vboxInstall.getLocation(),
       cygwinPath = cygwinInstall.getLocation(),
-      env = {};
+      env = Object.assign({},Platform.ENV);
 
-    env[Platform.PATH] = process.env[Platform.PATH]
+    env[Platform.PATH] = Platform.ENV[Platform.PATH]
       + path.delimiter + path.join(vgrPath,'bin')
       + (process.platform === 'win32' ? path.delimiter + path.join(cygwinPath,'bin') : '')
       + path.delimiter + vboxPath;

--- a/browser/services/platform.js
+++ b/browser/services/platform.js
@@ -16,6 +16,14 @@ class Platform {
   static getOS() {
     return process.platform;
   }
+
+  static get ENV() {
+    return Platform.getEnv();
+  }
+
+  static getEnv() {
+    return process.env;
+  }
 }
 
 Platform.PATH = Platform.identify({

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -224,10 +224,19 @@ describe('CDK installer', function() {
     });
 
     describe('createEnvironment', function() {
+
       it('should return path with vagrant/bin', function() {
         let env = installer.createEnvironment();
         expect(env[Platform.PATH]).includes(path.join(installerDataSvc.vagrantDir(), 'bin') + path.delimiter + installerDataSvc.vagrantDir());
       });
+
+      it('should return environmnet with VAGRANT_HOME defined', function() {
+        let processEnv = Object.assign({},process.env);
+        processEnv['VAGRANT_HOME'] = 'path/w/o/spaces';
+        sandbox.stub(Platform,'getEnv').returns(processEnv);
+        let env = installer.createEnvironment();
+        expect(env['VAGRANT_HOME']).to.be.not.equal(undefined);
+      })
     });
 
     describe('setupVagrant', function() {

--- a/test/unit/services/platform-test.js
+++ b/test/unit/services/platform-test.js
@@ -42,4 +42,12 @@ describe('Platform', function(){
 
   })
 
+  describe('PATH', function(){
+
+    describe("PATH does not return undefined value form process.env", function(){
+      expect(process.env[Platform.PATH]).to.be.not.equal(undefined);
+    })
+
+  })
+
 });


### PR DESCRIPTION
Fix restores previous approach and pass copy of process.env to
child process.