### PR TITLE
Code Cleanup: use Platform.OS and Platform.ENV throughout browser/**

### DIFF
--- a/browser/directives/breadcrumb.js
+++ b/browser/directives/breadcrumb.js
@@ -1,6 +1,4 @@
-'use strict'
-
-import angular from 'angular';
+'use strict';
 
 function breadcrumb($state) {
   return {

--- a/browser/directives/pathValidator.js
+++ b/browser/directives/pathValidator.js
@@ -1,6 +1,5 @@
-'use strict'
+'use strict';
 
-import angular from 'angular';
 import fs from 'fs';
 import path from 'path';
 import Platform from '../services/platform';

--- a/browser/directives/pathValidator.js
+++ b/browser/directives/pathValidator.js
@@ -3,6 +3,7 @@
 import angular from 'angular';
 import fs from 'fs';
 import path from 'path';
+import Platform from '../services/platform';
 
 let pathWindowsRegex = /^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$/;
 
@@ -42,7 +43,7 @@ function pathValidator() {
       mCtrl.$validators['notAbsolute'] = isAbsolute;
       mCtrl.$validators['tooLong'] = validateLength;
       mCtrl.$validators['hasSpaces'] = hasNoSpaces;
-      if(process.platform == 'win32') {
+      if(Platform.OS == 'win32') {
         mCtrl.$validators['invalidFormat'] = validateFormatWindows;
         mCtrl.$validators['invalidDisk'] = validateDisk;
       }

--- a/browser/directives/progressBar.js
+++ b/browser/directives/progressBar.js
@@ -1,6 +1,4 @@
-'use strict'
-
-import angular from 'angular';
+'use strict';
 
 function progressBar() {
   return {

--- a/browser/main.js
+++ b/browser/main.js
@@ -20,7 +20,6 @@ import JbdsInstall from './model/jbds';
 import VagrantInstall from './model/vagrant';
 import CygwinInstall from './model/cygwin';
 import CDKInstall from './model/cdk';
-import Util from './model/helpers/util';
 
 let mainModule =
       angular.module('devPlatInstaller', ['ui.router', 'base64', 'ngMessages'])

--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -2,7 +2,6 @@
 
 let fs = require('fs-extra');
 var filesystem = require("fs");
-let request = require('request');
 let path = require('path');
 
 import InstallableItem from './installable-item';
@@ -12,7 +11,6 @@ import Platform from '../services/platform';
 import VagrantInstall from './vagrant';
 import Installer from './helpers/installer';
 import Util from './helpers/util.js';
-import Hash from './helpers/hash.js';
 
 class CDKInstall extends InstallableItem {
   constructor(installerDataSvc, $timeout, cdkUrl, cdkBoxUrl, ocUrl, installFile, targetFolderName, cdkSha256, boxSha256, ocSha256) {

--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -140,10 +140,10 @@ class CDKInstall extends InstallableItem {
     installer.unzip(this.cdkDownloadedFile, this.installerDataSvc.installDir())
     .then((result) => { return installer.unzip(this.ocDownloadedFile, this.installerDataSvc.ocDir(), result); })
     .then((result) => { return installer.copyFile(this.cdkBoxDownloadedFile, path.join(this.installerDataSvc.cdkBoxDir(), this.boxName), result); })
-    .then((result) => { return process.platform === 'win32' ? installer.writeFile(this.pscpPathScript, data, result) : Promise.resolve(true); })
+    .then((result) => { return Platform.OS === 'win32' ? installer.writeFile(this.pscpPathScript, data, result) : Promise.resolve(true); })
     .then((result) => { return installer.writeFile(this.installerDataSvc.cdkMarker(), markerContent, result); })
-    .then((result) => { return process.platform === 'win32' ? installer.execFile('powershell', opts, result) : Promise.resolve(true); })
-    .then((result) => { return process.platform === 'win32' ? installer.exec('setx VAGRANT_DETECTED_OS "cygwin"') : Promise.resolve(true); })
+    .then((result) => { return Platform.OS === 'win32' ? installer.execFile('powershell', opts, result) : Promise.resolve(true); })
+    .then((result) => { return Platform.OS === 'win32' ? installer.exec('setx VAGRANT_DETECTED_OS "cygwin"') : Promise.resolve(true); })
     .then((result) => { return this.setupVagrant(installer, result); })
     .then((result) => { return installer.succeed(result); })
     .catch((error) => { return installer.fail(error); });
@@ -160,7 +160,7 @@ class CDKInstall extends InstallableItem {
 
     env[Platform.PATH] = Platform.ENV[Platform.PATH]
       + path.delimiter + path.join(vgrPath,'bin')
-      + (process.platform === 'win32' ? path.delimiter + path.join(cygwinPath,'bin') : '')
+      + (Platform.OS === 'win32' ? path.delimiter + path.join(cygwinPath,'bin') : '')
       + path.delimiter + vboxPath;
     Logger.info(CDKInstall.KEY + ' - Set PATH environment variable to \'' + env[Platform.PATH] + '\'');
 

--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -1,14 +1,9 @@
 'use strict';
 
-let fs = require('fs-extra');
-let request = require('request');
 let path = require('path');
 
 import InstallableItem from './installable-item';
-import Downloader from './helpers/downloader';
-import Logger from '../services/logger';
 import Installer from './helpers/installer';
-import VirtualBoxInstall from './virtualbox';
 import Util from './helpers/util';
 import Platform from '../services/platform';
 

--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -10,7 +10,7 @@ import Logger from '../services/logger';
 import Installer from './helpers/installer';
 import VirtualBoxInstall from './virtualbox';
 import Util from './helpers/util';
-
+import Platform from '../services/platform';
 
 class CygwinInstall extends InstallableItem {
   constructor(installerDataSvc, downloadUrl, installFile, targetFolderName, sha256) {
@@ -29,7 +29,7 @@ class CygwinInstall extends InstallableItem {
   }
 
   detectExistingInstall(done = function(){}) {
-    if (process.platform === 'win32') {
+    if (Platform.OS === 'win32') {
       let cygwinPackageRegex = /cygwin\s*(\d+\.\d+\.\d+)/,
           opensshPackageReqex = /openssh\s*(\d+\.\d+)/,
           rsyncPackageRegex = /rsync\s*(\d+\.\d+\.\d+)/;

--- a/browser/model/helpers/util.js
+++ b/browser/model/helpers/util.js
@@ -2,25 +2,26 @@
 
 let child_process = require('child_process');
 let fs = require('fs');
-let path = require('path');
+
+import Platform from '../../services/platform';
 
 class Util {
 
   static executeCommand(command, outputCode=1) {
     return new Promise((resolve, reject) => {
       let options = {
-        env : Object.assign({},process.env)
+        env : Object.assign({},Platform.ENV)
       };
-      if (process.platform == 'darwin') {
-          options.env.PATH = options.env.PATH + ':/usr/local/bin';
+      if (Platform.OS == 'darwin') {
+        options.env.PATH = options.env.PATH + ':/usr/local/bin';
       }
-      child_process.exec(command, options, defaultCallback(resolve, reject, outputCode))
+      child_process.exec(command, options, defaultCallback(resolve, reject, outputCode));
     });
   }
 
   static executeFile(file, args, outputCode=1) {
     return new Promise((resolve, reject) => {
-      child_process.execFile(file, args, defaultCallback(resolve, reject, outputCode))
+      child_process.execFile(file, args, defaultCallback(resolve, reject, outputCode));
     });
   }
 
@@ -58,7 +59,7 @@ class Util {
     return new Promise((resolve, reject) => {
       fs.readFile(file, encoding, (err, data) => {
         if(err) {
-          reject(err)
+          reject(err);
         } else {
           let lines = data.toString().split('\n');
           let result;
@@ -87,11 +88,12 @@ class Util {
   }
 
   static getRejectUnauthorized() {
-    let value = process.env['DSI_REJECT_UNAUTHORIZED'];
+    let value = Platform.ENV['DSI_REJECT_UNAUTHORIZED'];
     let result = true;
     try {
       result = JSON.parse(value);
     } catch (error) {
+      /* continue regardless of error */
     }
     return result;
   }
@@ -108,7 +110,7 @@ function defaultCallback(resolve,reject,outputCode) {
         resolve(stdout.toString().trim());
       }
     }
-  }
+  };
 }
 
 export default Util;

--- a/browser/model/jbds-autoinstall.js
+++ b/browser/model/jbds-autoinstall.js
@@ -2,6 +2,8 @@
 
 let path = require('path');
 
+import Platform from '../services/platform';
+
 class JbdsAutoInstallGenerator {
   constructor(jbdsInstallDir, jdkInstallDir, version) {
     this.autoInstall = this.generate(jbdsInstallDir, jdkInstallDir, version);
@@ -12,7 +14,7 @@ class JbdsAutoInstallGenerator {
   }
 
   generate(jbdsInstallDir, jdkInstallDir, jbdsVersion) {
-    let exeSuffix = process.platform === 'win32' ? 'w.exe' : '',
+    let exeSuffix = Platform.OS === 'win32' ? 'w.exe' : '',
     temp =
       [
         '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',

--- a/browser/model/jbds.js
+++ b/browser/model/jbds.js
@@ -1,6 +1,5 @@
-  'use strict';
+'use strict';
 
-let request = require('request');
 let path = require('path');
 let fs = require('fs-extra');
 let Glob = require("glob").Glob;
@@ -8,12 +7,12 @@ let replace = require("replace-in-file");
 
 import JbdsAutoInstallGenerator from './jbds-autoinstall';
 import InstallableItem from './installable-item';
-import Downloader from './helpers/downloader';
 import Installer from './helpers/installer';
 import Logger from '../services/logger';
 import JdkInstall from './jdk-install';
 import CDKInstall from './cdk.js';
 import Util from './helpers/util';
+import Platform from '../services/platform';
 
 class JbdsInstall extends InstallableItem {
   constructor(installerDataSvc, downloadUrl, installFile, targetFolderName, jbdsSha256) {
@@ -60,11 +59,11 @@ class JbdsInstall extends InstallableItem {
       return;
     }
 
-    if (process.platform === 'win32') {
+    if (Platform.OS === 'win32') {
       directory = selection ? selection[0] : 'c:';
       pattern = selection ? 'studio/devstudio.exe' : '**/studio/devstudio.exe';
     } else {
-      directory = selection ? selection[0] : process.env.HOME;
+      directory = selection ? selection[0] : Platform.ENV[Platform.HOME];
       pattern = selection ? 'studio/devstudio' : '{*,*/*,*/*/*,*/*/*/*}/studio/devstudio';
     }
 

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -8,6 +8,7 @@ var rimraf = require('rimraf');
 import InstallableItem from './installable-item';
 import Downloader from './helpers/downloader';
 import Logger from '../services/logger';
+import Platform from '../services/platform';
 import Installer from './helpers/installer';
 import CDKInstall from './cdk';
 import Util from './helpers/util';
@@ -77,7 +78,7 @@ class JdkInstall extends InstallableItem {
         }
         done();
     }).catch((error) => {
-      if(process.platform !== 'darwin' ) {
+      if(Platform.OS !== 'darwin' ) {
         this.selectedOption = 'install';
       }
       done();
@@ -99,7 +100,7 @@ class JdkInstall extends InstallableItem {
       msiSearchScript
     ];
     let result = Promise.resolve("");
-    if (process.platform === 'win32') {
+    if (Platform.OS === 'win32') {
       result = Util.writeFile(JdkInstall.KEY, msiSearchScript, data).then(()=>{
         return Util.executeFile('powershell', args);
       });

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -6,11 +6,9 @@ var rimraf = require('rimraf');
 
 
 import InstallableItem from './installable-item';
-import Downloader from './helpers/downloader';
 import Logger from '../services/logger';
 import Platform from '../services/platform';
 import Installer from './helpers/installer';
-import CDKInstall from './cdk';
 import Util from './helpers/util';
 import Version from './helpers/version';
 

--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -6,6 +6,7 @@ let fs = require('fs-extra');
 import InstallableItem from './installable-item';
 import Downloader from './helpers/downloader';
 import Logger from '../services/logger';
+import Platform from '../services/platform';
 import Installer from './helpers/installer';
 import CygwinInstall from './cygwin';
 import Util from './helpers/util';
@@ -35,7 +36,7 @@ class VagrantInstall extends InstallableItem {
         directory,
         extension = '',
         subfolder = path.sep + 'bin';
-    if (process.platform === 'win32') {
+    if (Platform.OS === 'win32') {
       command = 'where vagrant';
       extension = '.exe';
     } else {

--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -4,11 +4,8 @@ let path = require('path');
 let fs = require('fs-extra');
 
 import InstallableItem from './installable-item';
-import Downloader from './helpers/downloader';
-import Logger from '../services/logger';
 import Platform from '../services/platform';
 import Installer from './helpers/installer';
-import CygwinInstall from './cygwin';
 import Util from './helpers/util';
 import Version from './helpers/version';
 

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -1,6 +1,5 @@
 'use strict';
 
-let fs = require('fs-extra');
 let path = require('path');
 
 import InstallableItem from './installable-item';

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -4,7 +4,7 @@ let fs = require('fs-extra');
 let path = require('path');
 
 import InstallableItem from './installable-item';
-import Downloader from './helpers/downloader';
+import Platform from '../services/platform';
 import Logger from '../services/logger';
 import Installer from './helpers/installer';
 import Util from './helpers/util';
@@ -39,7 +39,7 @@ class VirtualBoxInstall extends InstallableItem {
     let extension = '';
     let directory;
 
-    if (process.platform === 'win32') {
+    if (Platform.OS === 'win32') {
       command = 'echo %VBOX_INSTALL_PATH%';
       extension = '.exe';
     } else {
@@ -50,7 +50,7 @@ class VirtualBoxInstall extends InstallableItem {
 
     Util.executeCommand(command, 1).then((output) => {
       return new Promise((resolve, reject) => {
-        if (process.platform === 'win32') {
+        if (Platform.OS === 'win32') {
           if (output === '%VBOX_INSTALL_PATH%') {
             return Util.executeCommand('echo %VBOX_MSI_INSTALL_PATH%', 1).then((output)=>{
                 resolve(output);

--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -6,6 +6,7 @@ let fs = require('fs');
 let path = require('path');
 
 import Logger from '../../services/logger';
+import Platform from '../../services/platform';
 
 class ConfirmController {
 
@@ -23,7 +24,7 @@ class ConfirmController {
 
     this.installables = {};
     $scope.checkboxModel = {};
-    $scope.platform = process.platform;
+    $scope.platform = Platform.OS;
     $scope.detectionStyle = false;
 
     for (var [key, value] of this.installerDataSvc.allInstallables().entries()) {

--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -2,8 +2,6 @@
 
 let remote = require('electron').remote;
 let dialog = remote.dialog;
-let fs = require('fs');
-let path = require('path');
 
 import Logger from '../../services/logger';
 import Platform from '../../services/platform';

--- a/browser/pages/location/controller.js
+++ b/browser/pages/location/controller.js
@@ -4,7 +4,6 @@ let remote = require('electron').remote;
 let dialog = remote.dialog;
 let fs = require('fs');
 let path = require('path');
-let ipcRenderer = require('electron').ipcRenderer;
 
 import Logger from '../../services/logger';
 import Util from '../../model/helpers/util';

--- a/browser/pages/start/controller.js
+++ b/browser/pages/start/controller.js
@@ -7,6 +7,7 @@ let shell = require('electron').shell;
 
 import Logger from '../../services/logger';
 import Util from '../../model/helpers/util';
+import Platform from '../../services/platform';
 
 class StartController {
 
@@ -15,7 +16,7 @@ class StartController {
     this.installerDataSvc = installerDataSvc;
     this.jbdsInstall = this.installerDataSvc.getInstallable('jbds');
     remote.getCurrentWindow().removeAllListeners('close');
-    this.launchDevstudio = this['launchDevstudio_' + process.platform];
+    this.launchDevstudio = this['launchDevstudio_' + Platform.OS];
   }
 
   learnCDK() {
@@ -88,7 +89,7 @@ class StartController {
 
     Logger.info('devstudio Start - Run runJbdsFile: ' + runJbdsFile);
 
-    let env = process.env;
+    let env = Platform.ENV;
     env['rhel.subscription.password'] = this.installerDataSvc.password;
     let runJbdsBat = require('child_process')
         .spawn(

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -3,6 +3,7 @@
 import InstallableItem from '../model/installable-item';
 import Logger from './logger';
 import Util from '../model/helpers/util';
+import Platform from '../services/platform';
 
 let os = require('os');
 let path = require('path');
@@ -12,13 +13,13 @@ let electron = require('electron');
 var mkdirp = require('mkdirp');
 
 class InstallerDataService {
-  constructor($state, reqs = require('../../requirements-' + process.platform + '.json')) {
+  constructor($state, reqs = require('../../requirements-' + Platform.OS + '.json')) {
     this.tmpDir = os.tmpdir();
 
-    if (process.platform === 'win32') {
+    if (Platform.OS === 'win32') {
       this.installRoot = 'c:\\DevelopmentSuite';
     } else {
-      this.installRoot = process.env.HOME + '/DevelopmentSuite';
+      this.installRoot = Platform.ENV.HOME + '/DevelopmentSuite';
   	}
     this.ipcRenderer = electron.ipcRenderer;
     this.router = $state;

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -1,8 +1,6 @@
 'use strict';
 
-import InstallableItem from '../model/installable-item';
 import Logger from './logger';
-import Util from '../model/helpers/util';
 import Platform from '../services/platform';
 
 let os = require('os');
@@ -20,7 +18,7 @@ class InstallerDataService {
       this.installRoot = 'c:\\DevelopmentSuite';
     } else {
       this.installRoot = Platform.ENV.HOME + '/DevelopmentSuite';
-  	}
+    }
     this.ipcRenderer = electron.ipcRenderer;
     this.router = $state;
 

--- a/browser/services/request.js
+++ b/browser/services/request.js
@@ -6,20 +6,20 @@ class Request {
   constructor(){
   }
 
- get(req) {
-   return new Promise((resolve,reject)=>{
-     request(req, (error, response, data) => {
-       if (!error && response.statusCode == 200) {
-         resolve({
-           status: response.statusCode,
-           data: JSON.parse(data)
-         });
-       } else {
-         reject();
-       }
-     });
-   });
- }
+  get(req) {
+    return new Promise((resolve,reject)=>{
+      request(req, (error, response, data) => {
+        if (!error && response.statusCode == 200) {
+          resolve({
+            status: response.statusCode,
+            data: JSON.parse(data)
+          });
+        } else {
+          reject();
+        }
+      });
+    });
+  }
 
   static factory() {
     return function(req) {


### PR DESCRIPTION
Fix migrates replaces process.env and process.platform
to correspondein Platform.ENV and Platform.OS class properties
to let test methods related to environments and specific OS.

See examples in cdk-tests createEnvironment tests.