### PR TITLE
JBDS-4165 Invalid Java Version '1.8.0.111' error in devtools console

### DIFF
--- a/requirements-win32.json
+++ b/requirements-win32.json
@@ -59,7 +59,7 @@
     "name": "OpenJDK",
     "description": "A free and open source implementation of the Java Platform, Standard Edition (Java SE)",
     "bundle": "yes",
-    "version": "1.8.0.111",
+    "version": "1.8.0_111",
     "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/java-1.8.0-openjdk-1.8.0.111-1.b15.redhat.windows.x86_64.msi?workflow=direct",
     "url": "http://download-node-02.eng.bos.redhat.com/brewroot/packages/openjdk8-win/1.8.0.111/1.b15/win/java-1.8.0-openjdk-1.8.0.111-1.b15.redhat.windows.x86_64.msi",
     "filename": "java-1.8.0-openjdk-1.8.0.111-1.b15.redhat.windows.x86_64.msi",


### PR DESCRIPTION
FIx updates format for Java Version in requirements-win32.json file