### PR TITLE
Update oc client tools for macOS

### DIFF
--- a/requirements-darwin.json
+++ b/requirements-darwin.json
@@ -27,10 +27,10 @@
     "description": "The Open Source Container Application Platform",
     "bundle": "yes",
     "version": "1.3.1",
-    "url": "https://github.com/openshift/origin/releases/download/v1.3.1/openshift-origin-client-tools-v1.3.1-dad658de7465ba8a234a4fb40b5b446a45a4cee1-mac.zip",
-    "filename": "openshift-origin-client-tools-v1.3.1-dad658de7465ba8a234a4fb40b5b446a45a4cee1-mac.zip",
-    "sha256sum": "3c941f0634566142784503e0b06c9c733bc1fda75b7b8cffb71f688b4f400d03",
-    "virusTotalReport": "https://virustotal.com/en/file/3c941f0634566142784503e0b06c9c733bc1fda75b7b8cffb71f688b4f400d03/analysis/",
+    "url": "https://github.com/openshift/origin/releases/download/v1.3.1/openshift-origin-client-tools-v1.3.1-2748423-mac.zip",
+    "filename": "openshift-origin-client-tools-v1.3.1-2748423-mac.zip",
+    "sha256sum": "252ee8a1ff8a455a9b55aff82f6980dbf28bd75b601414765b4f06f6c1ec370e",
+    "virusTotalReport": "https://virustotal.com/en/file/252ee8a1ff8a455a9b55aff82f6980dbf28bd75b601414765b4f06f6c1ec370e/analysis/",
     "vendor": "Red Hat, Inc."
   },
   "cygwin.exe": {


### PR DESCRIPTION
Fix includes update for macOS client tools.
Mac client tools have been rebuilt on top of Go 1.7 to fix
various issues related to the OS X Sierra update.