### PR TITLE
Update DevStudio build to latest nightly build

### DIFF
--- a/requirements-darwin.json
+++ b/requirements-darwin.json
@@ -49,10 +49,10 @@
     "description": "A certified Eclipse-based integrated development environment (IDE)",
     "bundle": "yes",
     "version": "10.2.0.AM3",
-    "dmUrl": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/latest/all/devstudio-10.2.0.latest-installer-standalone.jar",
-    "url": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/latest/all/devstudio-10.2.0.latest-installer-standalone.jar",
-    "filename": "devstudio-10.2.0.latest-installer-standalone.jar",
-    "sha256sum": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/latest/all/devstudio-10.2.0.latest-installer-standalone.jar.sha256",
+    "dmUrl": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/2016-11-08_01-24-40-B6398/all/devstudio-10.2.0.AM3-v20161108-0111-B6398-installer-standalone.jar",
+    "url": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/2016-11-08_01-24-40-B6398/all/devstudio-10.2.0.AM3-v20161108-0111-B6398-installer-standalone.jar",
+    "filename": "devstudio-10.2.0.AM3-latest-installer-standalone.jar",
+    "sha256sum": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/2016-11-08_01-24-40-B6398/all/devstudio-10.2.0.AM3-v20161108-0111-B6398-installer-standalone.jar.sha256",
     "vendor": "Red Hat, Inc."
   },
   "jdk.msi": {

--- a/requirements-win32.json
+++ b/requirements-win32.json
@@ -49,10 +49,10 @@
     "description": "A certified Eclipse-based integrated development environment (IDE)",
     "bundle": "yes",
     "version": "10.2.0.AM3",
-    "dmUrl": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/latest/all/devstudio-10.2.0.latest-installer-standalone.jar",
-    "url": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/latest/all/devstudio-10.2.0.latest-installer-standalone.jar",
-    "filename": "devstudio-10.2.0.latest-installer-standalone.jar",
-    "sha256sum": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/latest/all/devstudio-10.2.0.latest-installer-standalone.jar.sha256",
+    "dmUrl": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/2016-11-08_01-24-40-B6398/all/devstudio-10.2.0.AM3-v20161108-0111-B6398-installer-standalone.jar",
+    "url": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/2016-11-08_01-24-40-B6398/all/devstudio-10.2.0.AM3-v20161108-0111-B6398-installer-standalone.jar",
+    "filename": "devstudio-10.2.0.AM3-latest-installer-standalone.jar",
+    "sha256sum": "http://www.qa.jboss.com/binaries/devstudio/10.0/snapshots/builds/devstudio.product_master/2016-11-08_01-24-40-B6398/all/devstudio-10.2.0.AM3-v20161108-0111-B6398-installer-standalone.jar.sha256",
     "vendor": "Red Hat, Inc."
   },
   "jdk.msi": {


### PR DESCRIPTION
Fix includes direct links to avoid downloading after
new nightly version is published during demo