### PR TITLE
Improve code coverage for JDK Installer

### DIFF
--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -37,7 +37,7 @@ class InstallableItem {
     this.detectedInstallLocation = '';
 
     if (downloadUrl == null || downloadUrl == '') {
-    	throw(new Error(`No download URL set for ${keyName} Installer`));
+      throw(new Error(`No download URL set for ${keyName} Installer`));
     }
 
     this.downloadUrl = downloadUrl;
@@ -49,11 +49,11 @@ class InstallableItem {
 
     this.isCollapsed = true;
     this.option = new Set();
-    this.selectedOption = "install";
+    this.selectedOption = 'install';
 
     this.downloader = null;
-    this.downloadFolder = path.normalize(path.join(__dirname,"../../../.."));
-    this.downloadedFile = "";
+    this.downloadFolder = path.normalize(path.join(__dirname,'../../../..'));
+    this.downloadedFile = '';
 
     this.installAfter = undefined;
     this.ipcRenderer = ipcRenderer;
@@ -176,13 +176,8 @@ class InstallableItem {
     }
   }
 
-  setup(progress, success, failure) {
-    // To be overridden
-    success();
-  }
-
   changeIsCollapsed() {
-      this.isCollapsed = !this.isCollapsed;
+    this.isCollapsed = !this.isCollapsed;
   }
 
   hasOption(name) {

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -58,7 +58,7 @@ class JdkInstall extends InstallableItem {
           this.validateVersion();
           if(this.option['detected'].valid) {
             this.selectedOption = 'detected';
-          } else if(process.platform !== 'darwin') {
+          } else if(Platform.OS !== 'darwin') {
             this.selectedOption = 'install';
           }
           resolve(true);
@@ -66,13 +66,13 @@ class JdkInstall extends InstallableItem {
           reject('No java detected');
         }
       });
-    }).then((result) => {
+    }).then(() => {
       return Util.executeCommand(command, 2);
     }).then((output) => {
       let locationRegex = /java\.home*\s=*\s(.*)[\s\S]/;
       this.openJdk = output.includes('OpenJDK');
       var t = locationRegex.exec(output);
-      if(t.length > 1) {
+      if(t && t.length > 1) {
         this.option['detected'].location = t[1];
       } else {
         this.selectedOption = 'install';
@@ -151,7 +151,7 @@ class JdkInstall extends InstallableItem {
             this.installerDataSvc.jdkRoot = targetDir;
           }
           installer.succeed(true);
-        }).catch((err)=>{
+        }).catch(()=>{
           // location doesn't parsed correctly, nothing to verify just resolve and keep going
           installer.succeed(result);
         });


### PR DESCRIPTION
Fix adds platform specific tests to JDK unit tests,
corrects wrong expect calls and gets coverage to
back to 100%.