### PR TITLE
JBDS-4174 Install Vagrant and Virtualbox on macOS

### DIFF
--- a/browser/model/vagrant.js
+++ b/browser/model/vagrant.js
@@ -59,7 +59,11 @@ class VagrantInstall extends InstallableItem {
       this.validateVersion();
       done();
     }).catch((error) => {
-      this.addOption('install',this.version,path.join(this.installerDataSvc.installRoot,'vagrant'),true);
+      let installLocation = Platform.identify({
+        win32: ()=>path.join(this.installerDataSvc.installRoot,'vagrant'),
+        default: ()=>'/usr/local'
+      });
+      this.addOption('install',this.version,installLocation,true);
       done(error);
     });
   }

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -223,7 +223,11 @@ class VirtualBoxInstallDarwin extends VirtualBoxInstall {
       this.validateVersion();
       done();
     }).catch(() => {
-      this.addOption('install',this.version,path.join(this.installerDataSvc.installRoot,'virtualbox'),true);
+      let installLocation = Platform.identify({
+        win32: ()=>path.join(this.installerDataSvc.installRoot,'vagrant'),
+        default: ()=>'/usr/local/bin'
+      });
+      this.addOption('install',this.version,installLocation,true);
       done();
     });
   }


### PR DESCRIPTION
Fix changes location set for install options. On windows
location stays the same, but on macOS both Vagrant and Virtualbox
adds soft  links into /usr/loca/bin directory.