### PR TITLE
JBDS-4196 MSI installed OpenJDK detection does not work

### DIFF
--- a/test/unit/model/jdk-install-test.js
+++ b/test/unit/model/jdk-install-test.js
@@ -142,8 +142,6 @@ describe('JDK installer', function() {
       jdk.validateVersion();
     });
 
-
-
     describe('on windows', function(){
       it('should select openjdk for installation if no java detected', function(done) {
         sandbox.stub(Platform,'getOS').returns('win32');
@@ -194,8 +192,10 @@ describe('JDK installer', function() {
         let jdk = new JdkInstall(installerDataSvc, 'url', 'file');
         jdk.findMsiInstalledJava.restore();
         return jdk.detectExistingInstall(function() {
-          expect(Util.executeFile).to.have.been.calledOnce;
-          expect(Util.writeFile).to.have.been.calledOnce;
+          expect(Util.writeFile).to.have.been.calledWith(
+            jdk.getMsiSearchScriptLocation(),jdk.getMsiSearchScriptData());
+          expect(Util.executeFile).to.have.been.calledWith(
+            'powershell', jdk.getMsiSearchScriptPowershellArgs(jdk.getMsiSearchScriptLocation()));
           done();
         });
       });


### PR DESCRIPTION
Fix removes extra parameter from Util.writeFile call and changes
the tests to fail if Util.writeFile called with wrong parameters.