### PR TITLE
JBDS-4193 Build Bundle Installer for macOS

### DIFF
--- a/gulp-tasks/dist-darwin.js
+++ b/gulp-tasks/dist-darwin.js
@@ -1,3 +1,104 @@
 'use strict';
+
+const builder = require("electron-builder");
+const Platform = builder.Platform;
+const download = require('./download.js');
+const reqs = require('../requirements-darwin.json');
+const config = require('./config.js');
+const copy = require('gulp-copy');
+const rename = require('gulp-rename');
+const runSequence = require('run-sequence');
+const pjson = require('../package.json');
+const fs = require('fs-extra');
+
 module.exports = function(gulp) {
+
+  // prefetch all the installer dependencies so we can package them up into the .exe
+  gulp.task('prefetch', ['create-prefetch-cache-dir'], function() {
+    return download.prefetch(reqs, 'yes', config.prefetchFolder);
+  });
+
+  gulp.task('dist', function(){
+      return runSequence('clean','dist-simple','dist-bundle');
+  });
+
+  gulp.task('update-package',['update-requirements'], function() {
+    return Promise.resolve().then(()=> {
+        pjson.version = pjson.version.replace('GA','Alpha1');
+      }).then(()=>{
+        fs.writeFile('./transpiled/package.json', JSON.stringify(pjson, null, 2));
+      }).catch((err)=>{
+        console.log(err);
+      });
+  });
+
+  gulp.task('dist-bundle', ['prefetch','update-package'], function() {
+    const builder = require("electron-builder")
+    const Platform = builder.Platform
+
+    // Promise is returned
+    return builder.build({
+      targets: Platform.MAC.createTarget(),
+      devMetadata: {
+        build: {
+          appId: "com.redhat.devsuite.installer",
+          category: "public.app-category.developer-tools",
+          mac: {
+            icon: "resources/devsuite.icns",
+            target: "zip"
+          },
+          extraFiles: [{
+            "from": "requirements-cache",
+            "to": ".",
+            "filter": ["*"]
+          }]
+        },
+        directories: {
+          app : "transpiled"
+        },
+
+      }
+    }).then(() => {
+      let pn =pjson.productName;
+      let pv =pjson.version;
+      return gulp.src(`dist/mac/${pn}-${pv}-mac.zip`)
+        .pipe(rename(`devsuite-${pv}-bundle-installer-mac.zip`))
+        .pipe(gulp.dest(`dist/`));
+    }).catch((error) => {
+        // handle error
+    });
+  });
+
+  gulp.task('dist-simple', ['update-package'], function() {
+    const builder = require("electron-builder")
+    const Platform = builder.Platform
+
+    // Promise is returned
+    return builder.build({
+      targets: Platform.MAC.createTarget(),
+      devMetadata: {
+        build: {
+          appId: "com.redhat.devsuite.installer",
+          category: "public.app-category.developer-tools",
+          mac: {
+            icon: "resources/devsuite.icns",
+            target: "zip"
+          }
+        },
+        directories: {
+          app : "transpiled"
+        },
+
+      }
+    }).then(() => {
+      let pn =pjson.productName;
+      let pv =pjson.version;
+      return gulp.src(`dist/mac/${pn}-${pv}-mac.zip`)
+        .pipe(rename(`devsuite-${pv}-installer-mac.zip`))
+        .pipe(gulp.dest(`dist/`));
+    }).catch((error) => {
+
+    });
+  });
+
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,7 @@ gulp.task('create-dist-dir', function(cb) {
   return mkdirp(config.buildFolderPath, cb);
 })
 
-gulp.task('generate', ['create-modules-link','transpile:app'], function(cb) {
+gulp.task('generate', ['create-modules-link','update-requirements'], function(cb) {
   var electronVersion = pjson.devDependencies['electron'];
   var cmd = path.join('node_modules', '.bin') + path.sep + 'electron-packager transpiled ' + config.artifactName + ' --platform=' + config.artifactPlatform + ' --arch=' + config.artifactArch;
   cmd += ' --version=' + electronVersion + ' --out="' + config.buildFolderPath + '" --overwrite --asar=true';
@@ -133,21 +133,10 @@ gulp.task('update-requirements',['transpile:app'], function() {
     .then(updateDevStudioVersion)
     .then(updateDevStudioSha)
     .then(()=>{
-      fs.writeFile('./transpiled/requirements.json', JSON.stringify(reqs, null, 2));
+      fs.writeFile('./transpiled/requirements-'  + process.platform + '.json', JSON.stringify(reqs, null, 2));
     }).catch((err)=>{
       console.log(err);
     });
-});
-
-gulp.task('update-package-meta', function() {
-	let appPackage = require('./transpiled/package.json');
-	delete appPackage.build;
-	return Promise.resolve()
-		.then(()=>{
-			fs.writeFile('./transpiled/package.json', JSON.stringify(appPackage, null, 2));
-		}).catch((err)=>{
-			console.log(err);
-		});
 });
 
 gulp.task('test', function() {

--- a/package.json
+++ b/package.json
@@ -14,14 +14,6 @@
     "url": "https://issues.jboss.org/projects/JBDS/summary"
   },
   "homepage": "https://github.com/redhat-developer-tooling/developer-platform-install#readme",
-  "build": {
-    "appId": "com.redhat.devsuite.installer",
-    "category": "public.app-category.developer-tools",
-    "mac": {
-      "icon": "resources/devsuite.icns",
-      "target": "zip"
-    }
-  },
   "directories": {
     "app" : "transpiled"
   },
@@ -34,7 +26,7 @@
     "test": "gulp test",
     "ui-test": "gulp ui-test",
     "system-test": "gulp system-test",
-    "dist:mac": "gulp clean && gulp transpile:app && gulp update-package-meta && node_modules/.bin/build"
+    "dist:mac": "gulp dist"
   },
   "dependencies": {
     "angular": "1.5.8",


### PR DESCRIPTION
Fix:
* refactors mac build to use electron-builder API
   instead of configuration and implements gulp 'dist' task
   for macOS
* includes version update from GA to Alpha1 for macOS