### PR TITLE
Update gulp to relative path ./node_modules/.bin/gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Build output is two installers. The main difference between them is a file size.
 Architecture
 ------------
 
-This installer is desktop application for Windows and macOS built with [Electron](http://electron.atom.io/docs/tutorial/about/). 
+This installer is desktop application for Windows and macOS built with [Electron](http://electron.atom.io/docs/tutorial/about/).
 
 Configuring development environment
 -----------------------------------
@@ -29,9 +29,8 @@ In order to build the installer, you'll need to install some tools.
 
 Note that your system might have an "AppData" (no space) instead of "App Data" (with space) folder, so make sure you use the correct path for your system.
 
-5. Install Gulp and all dependencies:
+5. Install all dependencies:
 
-        npm install -g gulp
         npm install
 
 If either of the above steps fail, try deleting the c:\Users\<username>\.electron folder.
@@ -90,9 +89,9 @@ of any test, e.g.:
 
     npm test -- -g login
     npm test -- --grep login
-    
+
 Unit tests code govergare is calculated by Istanbul. By default it generates html and raw coverage reports. Report format can be overriden with '--report' parameter like shown below
-    
+
     npm test -- --report cobertura
 
 Running Angular protractor UI tests
@@ -187,7 +186,7 @@ developers.redhat.com with download-manager links. In separate windows execute
 
     node gulp-tasks/https-server.js
 
-Now you are ready to test online installer without actual bits published to 
+Now you are ready to test online installer without actual bits published to
 download-manager. Start dist/win/DevelopmentSuiteInstaller-win32-x64-*.exe
 from package explorer and use it as you would normally do after release.
 

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
     "app": "transpiled"
   },
   "scripts": {
-    "start": "gulp run",
-    "generate": "gulp generate",
-    "package-bundle": "gulp package-bundle",
-    "package-simple": "gulp package-simple",
+    "start": "./node_modules/.bin/gulp run",
+    "generate": "./node_modules/.bin/gulp generate",
+    "package-bundle": "./node_modules/.bin/gulp package-bundle",
+    "package-simple": "./node_modules/.bin/gulp package-simple",
     "coverage:publish": "codecov",
-    "dist": "gulp dist",
-    "test": "gulp test",
-    "ui-test": "gulp ui-test",
-    "system-test": "gulp system-test",
-    "dist:mac": "gulp dist"
+    "dist": "./node_modules/.bin/gulp dist",
+    "test": "./node_modules/.bin/gulp test",
+    "ui-test": "./node_modules/.bin/gulp ui-test",
+    "system-test": "./node_modules/.bin/gulp system-test",
+    "dist:mac": "./node_modules/.bin/gulp dist"
   },
   "dependencies": {
     "angular": "1.5.8",


### PR DESCRIPTION
Fix updates gulp to full relative path in package.json
to avoid addition step with gulp global installation to
configure development environment.
It also removes gulp global installation step from readme.md.