### PR TITLE
Add spec-file parameter to unit-test gulp task

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build installer follow steps below for specific platform.
 
 1. Download and install nvm for Windows from <https://github.com/coreybutler/nvm-windows/>. Pick the MSI installer.
 
-2. Install nodejs using 
+2. Install nodejs using
 
         nvm install 6.9.1
 
@@ -187,6 +187,15 @@ of any test, e.g.:
 
     npm test -- -g login
     npm test -- --grep login
+
+To run tests from specific file --spec-file parameter can be used to override default pattern to select files to run.
+Parameter value can be specific file name
+
+    npm test -- --spec-file test/unit/pages/account/controller-test.js
+
+or globe pattern
+
+    npm test -- --spec-file=test/unit/pages/**/*.js
 
 Unit tests code govergare is calculated by Istanbul. By default it generates html and raw coverage reports. Report format can be overriden with '--report' parameter like shown below
 

--- a/gulp-tasks/tests.js
+++ b/gulp-tasks/tests.js
@@ -2,13 +2,13 @@ var angularProtractor = require('gulp-angular-protractor'),
   exec = require('child_process').exec,
   mocha = require('gulp-spawn-mocha'),
   path = require('path');
-  
+
 var yargs = require('yargs');
 var buildFolder = path.join('dist', process.platform + '-' + process.arch);
 
 module.exports = function(gulp) {
   gulp.task('unit-test', function() {
-    return gulp.src(['test/unit/**/*.js'], {
+    return gulp.src([yargs.argv['spec-file'] || 'test/unit/**/*.js'], {
       read: false
     }).pipe(mocha({
       recursive: true,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,9 +131,7 @@ gulp.task('update-requirements', ['transpile:app'], function() {
     });
 });
 
-gulp.task('test', function() {
-  return runSequence('unit-test');
-});
+gulp.task('test', ['unit-test']);
 
 gulp.task('ui-test', function(cb) {
   process.env.PTOR_TEST_RUN = 'ui';


### PR DESCRIPTION
This allows to run specific tests in file not the whole suite.
It accepts globe patterns as well.