### PR TITLE
Restore logger to original state after tests

### DIFF
--- a/test/unit/services/logger-test.js
+++ b/test/unit/services/logger-test.js
@@ -9,14 +9,18 @@ import Electron from 'electron';
 chai.use(sinonChai);
 
 describe('Logger', function() {
-  let sandbox, ipcRenderer;
+  let sandbox, ipcRenderer, getIpcRendererStub;
 
   before(function() {
     ipcRenderer = {
       send: function() {}
     };
     expect(Logger.getIpcRenderer()).to.equal(Electron.ipcRenderer);
-    Logger.getIpcRenderer = function () { return ipcRenderer; };
+    getIpcRendererStub = sinon.stub(Logger, 'getIpcRenderer').returns(ipcRenderer);
+  });
+
+  after(function() {
+    getIpcRendererStub.restore();
   });
 
   beforeEach(function() {


### PR DESCRIPTION
Fix adds after() method where Logger.getIpcRenderer method restored to
original.