### PR TITLE
Remove debug error from cdk watcher

### DIFF
--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -48,7 +48,6 @@ class ConfirmController {
           $scope.checkboxModel.cygwin.selectedOption = 'install';
         }
       }
-      throw Error('test');
     });
 
     $scope.$watch('checkboxModel.jbds.selectedOption', function watchDevStudioSelectionChange(nVal) {


### PR DESCRIPTION
I couldn't find any practical use for it and it just clutters the console.