### PR TITLE
JBDS-4245 rename minishift zip to cdk to have the filenames match

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -20,7 +20,7 @@ class CDKInstall extends InstallableItem {
     this.cdkIsoSha256 = cdkIsoSha256;
     this.ocSha256 = ocSha256;
 
-    this.minishiftFileName = 'minishift.zip';
+    this.minishiftFileName = 'cdk.zip';
     this.mnishiftDownloadedFile = path.join(this.installerDataSvc.tempDir(), this.minishiftFileName);
 
     this.boxName = 'rhel.iso';


### PR DESCRIPTION
so the bundled installer can find the file