### PR TITLE
JBDS-4249 remove outdated cached dependencies before build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,12 @@ gulp.task('clean-all', ['clean'], function() {
 
 // clean dist/ folder in prep for fresh build
 gulp.task('clean', function() {
-  return del(['dist', 'transpiled'], { force: true });
+  var files = ['dist', 'transpiled', config.prefetchFolder + '/*'];
+  for (var key in reqs) {
+    files.push('!' + config.prefetchFolder + '/' + reqs[key].filename);
+  }
+
+  return del(files, { force: true });
 });
 
 gulp.task('create-dist-dir', function(cb) {


### PR DESCRIPTION
Remove dependency files that are not declared in requirements.json before bundling them, so they don't get used after file name change, etc. Requires #500 to be merged first for the filenames to match requirements.json 