### PR TITLE
JBDS-4250 CDK installer: latest minishift installer fails on MacOS

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -118,9 +118,9 @@ class CDKInstall extends InstallableItem {
       'rhel.subscription.username=' + this.installerDataSvc.getUsername()
     ].join('\r\n');
     let ocDir = this.installerDataSvc.ocDir();
-    installer.unzip(this.downloadedFile, ocDir)
+    installer.unzip(this.downloadedFile, ocDir, Platform.OS === 'win32' ? '' :'darwin-amd64/')
     .then(() => { return Platform.OS === 'win32' ? Promise.resolve(true) : installer.exec(`chmod +x ${ocDir}/minishift`); })
-    .then((result) => { return installer.unzip(this.ocDownloadedFile, ocDir, result); })
+    .then((result) => { return installer.unzip(this.ocDownloadedFile, ocDir); })
     .then(() => { return Platform.OS === 'win32' ? Promise.resolve(true) : installer.exec(`chmod +x ${ocDir}/oc`); })
     .then((result) => { return installer.copyFile(this.cdkIsoDownloadedFile, path.join(this.installerDataSvc.cdkBoxDir(), this.boxName), result); })
     .then((result) => { return Platform.OS === 'win32' ? installer.writeFile(this.pscpPathScript, data, result) : Promise.resolve(true); })

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "angular": "1.6.1",
-    "angular-mocks": "1.6.1",
     "angular-base64": "2.0.5",
     "angular-messages": "1.6.1",
+    "angular-mocks": "1.6.1",
     "angular-ui-router": "0.3.2",
     "fs-extra": "1.0.0",
     "glob": "7.1.1",
@@ -43,6 +43,7 @@
     "request": "2.79.0",
     "rimraf": "2.5.4",
     "semver": "5.3.0",
+    "targz": "1.0.1",
     "unzip": "0.1.11"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix adds:
* check for archive extension in Installer.unzip
* targz unpack for tar.gz files
* prefix to copy minishift.exe only without darwin-amd64 folder