### PR TITLE
JBDS-4155 Add progress statuses for checksum verification

### DIFF
--- a/browser/directives/progressBar.html
+++ b/browser/directives/progressBar.html
@@ -7,7 +7,8 @@
           <div>{{productDesc}}</div>
         </div>
         <div class="progress progress-label-top-right">
-          <div class="progress-bar" ng-class="{'progress-bar-striped active': status == 'Installing' || status == 'Setting up' || status.indexOf('Waiting') > -1}" role="progressbar" aria-valuenow="{{current}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}"
+          <div class="progress-bar" ng-class="{'progress-bar-striped active': status == 'Installing' || status == 'Setting up' || status.indexOf('Waiting') > -1 || status.indexOf('Verifying') > -1}"
+            role="progressbar" aria-valuenow="{{current}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}"
             style="width: {{current}}%; animation: progress-bar-stripes 2s infinite steps(15);">
             <span>{{label}}</span>
           </div>

--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -42,8 +42,6 @@ class CDKInstall extends InstallableItem {
   }
 
   downloadInstaller(progress, success, failure) {
-    progress.setStatus('Downloading');
-
     let totalDownloads = 3;
     this.downloader = new Downloader(progress, success, failure, totalDownloads);
     let username = this.installerDataSvc.getUsername();
@@ -59,7 +57,8 @@ class CDKInstall extends InstallableItem {
         this.cdkIsoUrl,
         this.cdkIsoSha256,
         username,
-        password
+        password,
+        progress
       );
     }
 
@@ -72,7 +71,8 @@ class CDKInstall extends InstallableItem {
         this.getDownloadUrl(),
         this.minishiftSha256,
         username,
-        password
+        password,
+        progress
       );
     }
 
@@ -84,7 +84,10 @@ class CDKInstall extends InstallableItem {
       this.checkAndDownload(
         this.ocDownloadedFile,
         this.ocUrl,
-        this.ocSha256
+        this.ocSha256,
+        undefined,
+        undefined,
+        progress
       );
     }
   }

--- a/browser/model/helpers/downloader.js
+++ b/browser/model/helpers/downloader.js
@@ -69,6 +69,9 @@ class Downloader {
     if(sha) {
       Logger.log(`Configured file='${file}' sha256='${sha}'`);
       var h = new Hash();
+      if(this.progress.current === 100) {
+        this.progress.setStatus('Verifying Download');
+      }
       h.SHA256(file, (dlSha) => {
         if(sha === dlSha) {
           Logger.log(`Downloaded file='${file}' sha256='${dlSha}'`);

--- a/browser/pages/install/controller.js
+++ b/browser/pages/install/controller.js
@@ -136,6 +136,9 @@ class ProgressState {
   }
 
   setStatus(newStatus) {
+    if (newStatus === this.status) {
+      return;
+    }
     if (newStatus !== 'Downloading') {
       this.current = 100;
       this.label = '';

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -112,7 +112,6 @@ describe('CDK installer', function() {
     it('should set progress to "Downloading"', function() {
       installer.downloadInstaller(fakeProgress, success, failure);
 
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
       expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
     });
 

--- a/test/unit/model/jdk-install-test.js
+++ b/test/unit/model/jdk-install-test.js
@@ -245,6 +245,7 @@ describe('JDK installer', function() {
     });
 
     it('should set progress to "Downloading"', function() {
+      sandbox.stub(fs, 'existsSync').returns(false);
       installer.downloadInstaller(fakeProgress, success, failure);
 
       expect(fakeProgress.setStatus).to.have.been.calledOnce;


### PR DESCRIPTION
Adding new statuses for the two possible sha checks, since otherwise downloads would seem to be stuck for a while on 0 or 100%:
 - 'Verifying Existing Download' - for checking existing downloaded files
 - 'Verifying Download' - for sha check after download finishes

Both will be presented with an indeterminate bar.