### PR TITLE
Progress bar refactoring

### DIFF
--- a/browser/directives/progressBar.html
+++ b/browser/directives/progressBar.html
@@ -1,16 +1,16 @@
-<div class="panel panel-default">
+<div class="panel panel-default" id="{{progress.key}}-progress">
   <div class="panel-heading">
     <div class="product-container">
       <div>
         <div class="progress-description">
-          <span class="product-name">{{productName}}</span><span class="product-version">{{productVersion}}</span> - <span class="product-version">{{status}}</span>
-          <div>{{productDesc}}</div>
+          <span class="product-name">{{progress.productName}}</span><span class="product-version">{{progress.productVersion}}</span> - <span class="product-version">{{progress.status}}</span>
+          <div>{{progress.productDesc}}</div>
         </div>
         <div class="progress progress-label-top-right">
-          <div class="progress-bar" ng-class="{'progress-bar-striped active': status == 'Installing' || status == 'Setting up' || status.indexOf('Waiting') > -1 || status.indexOf('Verifying') > -1}"
-            role="progressbar" aria-valuenow="{{current}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}"
-            style="width: {{current}}%; animation: progress-bar-stripes 2s infinite steps(15);">
-            <span>{{label}}</span>
+          <div class="progress-bar" ng-class="{'progress-bar-striped active': progress.status == 'Installing' || progress.status == 'Setting up' || progress.status.indexOf('Waiting') > -1 || progress.status.indexOf('Verifying') > -1}"
+            role="progressbar" aria-valuenow="{{progress.current}}" aria-valuemin="{{progress.min}}" aria-valuemax="{{progress.max}}"
+            style="width: {{progress.current}}%; animation: progress-bar-stripes 2s infinite steps(15);">
+            <span>{{progress.label}}</span>
           </div>
         </div>
       </div>

--- a/browser/directives/progressBar.js
+++ b/browser/directives/progressBar.js
@@ -5,14 +5,7 @@ function progressBar() {
     restrict: 'E',
     replace: true,
     scope: {
-      productName: '=',
-      productVersion: '=',
-      productDesc: '=',
-      current: '=',
-      min: '=',
-      max: '=',
-      label: '=',
-      status: '='
+      progress: '='
     },
     templateUrl: 'directives/progressBar.html'
   };

--- a/browser/pages/install/install.html
+++ b/browser/pages/install/install.html
@@ -6,26 +6,12 @@
 <main class="col-sm-12">
   <div class="col-sm-12">
     <h3>Installation Details{{checkboxModel.jdk.selected}}</h3>
-    <div>
-      <progress-bar id="virtualbox-progress" ng-show="instCtrl.show('virtualbox')" name="virtualbox" product_name="instCtrl.productName('virtualbox')" product_version="instCtrl.productVersion('virtualbox')" current="instCtrl.current('virtualbox')" min="0" max="100" label="instCtrl.label('virtualbox')" product_desc="instCtrl.productDesc('virtualbox')" status="instCtrl.status('virtualbox')">
-      </progress-bar>
-    </div>
-    <div>
-      <progress-bar id="cygwin-progress" ng-show="instCtrl.show('cygwin')" name="cygwin" product_name="instCtrl.productName('cygwin')" product_version="instCtrl.productVersion('cygwin')" current="instCtrl.current('cygwin')" min="0" max="100" label="instCtrl.label('cygwin')" product_desc="instCtrl.productDesc('cygwin')" status="instCtrl.status('cygwin')">
-      </progress-bar>
-    </div>
-    <div>
-      <progress-bar id="cdk-progress" ng-show="instCtrl.show('cdk')" name="cdk" product_name="instCtrl.productName('cdk')" product_version="instCtrl.productVersion('cdk')" current="instCtrl.current('cdk')" min="0" max="100" label="instCtrl.label('cdk')" product_desc="instCtrl.productDesc('cdk')" status="instCtrl.status('cdk')">
-      </progress-bar>
-    </div>
-    <div>
-      <progress-bar id="jdk-progress" ng-show="instCtrl.show('jdk')" name="jdk" product_name="instCtrl.productName('jdk')" product_version="instCtrl.productVersion('jdk')" current="instCtrl.current('jdk')" min="0" max="100" label="instCtrl.label('jdk')" product_desc="instCtrl.productDesc('jdk')" status="instCtrl.status('jdk')">
-      </progress-bar>
-    </div>
-    <div>
-      <progress-bar id="devstudio-progress" ng-show="instCtrl.show('jbds')" name="jbds" product_name="instCtrl.productName('jbds')" product_version="instCtrl.productVersion('jbds')" current="instCtrl.current('jbds')" min="0" max="100" label="instCtrl.label('jbds')" product_desc="instCtrl.productDesc('jbds')" status="instCtrl.status('jbds')">
-      </progress-bar>
-    </div>
+    <ng-repeat ng-repeat="progress in data">
+      <div>
+        <progress-bar progress="progress">
+        </progress-bar>
+      </div>
+    </ng-repeat>
   </div>
 </main>
 

--- a/test/ui/install-test.js
+++ b/test/ui/install-test.js
@@ -12,7 +12,7 @@ describe('Installation page', function() {
     cygwin: requirements['cygwin'],
     cdk: requirements['cdk'],
     jdk: requirements['jdk'],
-    devstudio: requirements['jbds']
+    jbds: requirements['jbds']
   };
 
   beforeAll(function() {

--- a/test/unit/pages/install/controller-test.js
+++ b/test/unit/pages/install/controller-test.js
@@ -51,7 +51,7 @@ describe('Install controller', function() {
   describe('constrution', function() {
     it('should process all installables', function() {
       let stub = sandbox.stub(InstallController.prototype, 'processInstallable').returns();
-      new InstallController(null, null, installerDataSvc);
+      new InstallController({}, {}, installerDataSvc);
 
       expect(stub).calledOnce;
       expect(stub).calledWith(VirtualBoxInstall.KEY, vbox);
@@ -61,7 +61,7 @@ describe('Install controller', function() {
       let stub = sandbox.stub(installerDataSvc, 'setupDone').returns();
       sandbox.stub(InstallController.prototype, 'processInstallable').returns();
       sandbox.stub(vbox, 'isSkipped').returns(true);
-      new InstallController(null, null, installerDataSvc);
+      new InstallController({}, {}, installerDataSvc);
       expect(stub).calledOnce;
     });
   });
@@ -85,20 +85,20 @@ describe('Install controller', function() {
     });
 
     it('should trigger download on not downloaded installables', function() {
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
 
       expect(dlStub).calledOnce;
       expect(dlStub).calledWith('virtualbox', vbox);
     });
 
     it('should not trigger download on already downloaded items', function() {
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
 
     });
 
     it('should trigger install on already downloaded items', function() {
       sandbox.stub(vbox, 'isDownloadRequired').returns(false);
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
 
       expect(inStub).calledOnce;
       expect(inStub).calledWith('virtualbox', vbox);
@@ -115,7 +115,7 @@ describe('Install controller', function() {
 
     it('data service should register the new downloads', function() {
       let spy = sandbox.spy(installerDataSvc, 'startDownload');
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
 
       expect(spy).calledOnce;
       expect(spy).calledWith('virtualbox');
@@ -127,14 +127,14 @@ describe('Install controller', function() {
     it('should call the installables downloadInstaller method', function() {
       sandbox.stub(installerDataSvc, 'startDownload').returns();
 
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
       expect(vboxStub).calledOnce;
     });
 
     it('should call data services downloadDone when download finishes', function() {
       sandbox.stub(installerDataSvc, 'startDownload').returns();
 
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
 
       expect(doneStub).calledOnce;
       expect(doneStub).calledWith(sinon.match.any, 'virtualbox');
@@ -152,7 +152,7 @@ describe('Install controller', function() {
 
     it('data service should register the new install', function() {
       let spy = sandbox.spy(installerDataSvc, 'startInstall');
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
 
       expect(spy).calledOnce;
       expect(spy).calledWith('virtualbox');
@@ -164,14 +164,14 @@ describe('Install controller', function() {
     it('should call the installables install method', function() {
       sandbox.stub(installerDataSvc, 'startInstall').returns();
 
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
       expect(vboxStub).calledOnce;
     });
 
     it('should call data services installDone when install finishes', function() {
       sandbox.stub(installerDataSvc, 'startInstall').returns();
 
-      new InstallController(null, timeoutStub, installerDataSvc);
+      new InstallController({}, timeoutStub, installerDataSvc);
 
       expect(doneStub).calledOnce;
       expect(doneStub).calledWith(sinon.match.any, 'virtualbox');


### PR DESCRIPTION
* Pass whole ProgressStatus instance to the directive
* Use ng-repeat to show progress bars for components being installed
* Simplify call for angular digest when status or progress changes
* update ui and unit tests to pass