### PR TITLE
JBDS-4223 Promisify Installer detection methods

### DIFF
--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -65,11 +65,7 @@ class ConfirmController {
     $scope.$watch('$viewContentLoaded', ()=>{
       let detectors = [];
       for (var installer of this.installerDataSvc.allInstallables().values()) {
-        detectors.push(new Promise((resolve)=> {
-          installer.detectExistingInstall().then(()=> {
-            resolve();
-          });
-        }));
+        detectors.push(installer.detectExistingInstall());
       }
       Promise.all(detectors).then(()=> {
         this.setIsDisabled();

--- a/test/unit/model/cygwin-test.js
+++ b/test/unit/model/cygwin-test.js
@@ -264,7 +264,7 @@ describe('Cygwin installer', function() {
         Util.executeCommand.onSecondCall().returns('/path/to/cygwin');
         installer = new CygwinInstall(installerDataSvc, downloadUrl, 'cygwin.exe', 'cygwin', 'sha');
         installer.ipcRenderer = { on: function() {} };
-        installer.detectExistingInstall(function() {
+        installer.detectExistingInstall().then(()=> {
           expect(installer.selectedOption).to.be.equal('install');
           expect(installer.hasOption('install')).to.be.equal(true);
         });


### PR DESCRIPTION
This change contains minor fixes related to promisified detection methods. It:
1. Removes wrapping promise for installer#detectExistingInstall call, which is not required because it now returns promise instance;
2. Fix one test case to use promise instead of callback.