### PR TITLE
Remove detectExistinInstall method from cdk and devstudio installer

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -23,10 +23,6 @@ class CDKInstall extends InstallableItem {
     return 'cdk';
   }
 
-  detectExistingInstall() {
-    return Promise.resolve();
-  }
-
   installAfterRequirements(progress, success, failure) {
     progress.setStatus('Installing');
     let cdkDotFolder;

--- a/browser/model/jbds.js
+++ b/browser/model/jbds.js
@@ -42,10 +42,6 @@ class JbdsInstall extends InstallableItem {
     });
   }
 
-  detectExistingInstall() {
-    return Promise.resolve();
-  }
-
   checkForExistingInstall(selection, data) {
     let pattern, directory;
     let versionRegex = /version\s(\d+)\.\d+\.\d+/;


### PR DESCRIPTION
Fix removes detectExistingInstall metjods because base class already
has the same default implementation.