### PR TITLE
Update dependencies to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "patternfly": "3.22.1",
     "pify": "2.3.0",
     "replace-in-file": "2.5.0",
-    "request": "2.80.0",
+    "request": "2.81.0",
     "rimraf": "2.6.1",
     "del": "2.2.2",
     "semver": "5.3.0",
@@ -49,14 +49,14 @@
     "unzip": "0.1.11"
   },
   "devDependencies": {
-    "babel-core": "6.23.1",
+    "babel-core": "6.24.0",
     "babel-preset-node5": "12.0.1",
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
     "codecov": "1.0.1",
     "crypto": "0.0.3",
     "electron": "1.6.2",
-    "electron-builder": "15.1.1",
+    "electron-builder": "15.4.3",
     "electron-packager": "8.5.2",
     "eslint": "3.17.1",
     "gulp": "3.9.1",
@@ -79,12 +79,12 @@
     "minimatch": "3.0.3",
     "mkdirp": "0.5.1",
     "mocha": "3.2.0",
-    "mock-fs": "4.1.0",
+    "mock-fs": "4.2.0",
     "npm-check-updates": "2.10.3",
     "pem": "1.9.4",
     "protractor": "5.1.1",
     "querystring": "0.2.0",
-    "rcedit": "0.7.0",
+    "rcedit": "0.8.0",
     "request-progress": "3.0.0",
     "run-sequence": "1.2.2",
     "sinon": "1.17.7",
@@ -92,6 +92,6 @@
     "sinon-chai": "2.8.0",
     "tmp": "0.0.31",
     "xunit-file": "1.0.0",
-    "yargs": "7.0.1"
+    "yargs": "7.0.2"
   }
 }


### PR DESCRIPTION
 request           2.80.0  →  2.81.0
 babel-core        6.23.1  →  6.24.0
 electron-builder  15.1.1  →  15.4.3
 mock-fs            4.1.0  →   4.2.0
 rcedit             0.7.0  →   0.8.0
 yargs              7.0.1  →   7.0.2