### PR TITLE
JBDS-4301 Allow loading subset of components from requirements.json

### DIFF
--- a/browser/main.js
+++ b/browser/main.js
@@ -14,133 +14,79 @@ import progressBar from './directives/progressBar';
 import breadcrumb from './directives/breadcrumb';
 import InstallerDataService from './services/data';
 import Request from './services/request';
-import VirtualBoxInstall from './model/virtualbox';
-import JdkInstall from './model/jdk-install';
-import DevstudioInstall from './model/devstudio';
-import CygwinInstall from './model/cygwin';
-import CDKInstall from './model/cdk';
-import HypervInstall from './model/hyperv';
+import ComponentLoader from './services/componentLoader';
 import Electron from 'electron';
 
 let mainModule =
-      angular.module('devPlatInstaller', ['ui.router', 'base64', 'ngMessages'])
-          .controller(acctCtrl.name, acctCtrl)
-          .controller(locCtrl.name, locCtrl)
-          .controller(confCtrl.name, confCtrl)
-          .controller(instCtrl.name, instCtrl)
-          .controller(startCtrl.name, startCtrl)
-          .factory('installerDataSvc', InstallerDataService.factory)
-          .factory('request', Request.factory)
-          .value('electron', Electron)
-          .directive(progressBar.name, progressBar)
-          .directive(breadcrumb.name, breadcrumb)
-          .directive(pathValidator.name, pathValidator)
-          .config( ['$stateProvider', '$urlRouterProvider', ($stateProvider, $urlRouterProvider) => {
-            $urlRouterProvider.otherwise('/account');
+  angular.module('devPlatInstaller', ['ui.router', 'base64', 'ngMessages'])
+    .controller(acctCtrl.name, acctCtrl)
+    .controller(locCtrl.name, locCtrl)
+    .controller(confCtrl.name, confCtrl)
+    .controller(instCtrl.name, instCtrl)
+    .controller(startCtrl.name, startCtrl)
+    .factory('installerDataSvc', InstallerDataService.factory)
+    .factory('request', Request.factory)
+    .value('electron', Electron)
+    .directive(progressBar.name, progressBar)
+    .directive(breadcrumb.name, breadcrumb)
+    .directive(pathValidator.name, pathValidator)
+    .config( ['$stateProvider', '$urlRouterProvider', ($stateProvider, $urlRouterProvider) => {
+      $urlRouterProvider.otherwise('/account');
 
-            $stateProvider
-              .state('account', {
-                url: '/account',
-                controller: 'AccountController as acctCtrl',
-                templateUrl: 'pages/account/account.html'
-              })
-              .state('location', {
-                url: '/location',
-                controller: 'LocationController as locCtrl',
-                templateUrl: 'pages/location/location.html',
-                data: {
-                  displayName: 'Target Folder'
-                }
-              })
-              .state('confirm', {
-                url: '/confirm',
-                controller: 'ConfirmController as confCtrl',
-                templateUrl: 'pages/confirm/confirm.html',
-                data: {
-                  displayName: 'Confirmation'
-                }
-              })
-              .state('install', {
-                url: '/install',
-                controller: 'InstallController as instCtrl',
-                templateUrl: 'pages/install/install.html',
-                data: {
-                  displayName: 'Download & Install'
-                }
-              })
-              .state('start', {
-                url: '/start',
-                controller: 'StartController as startCtrl',
-                templateUrl: 'pages/start/start.html',
-                data: {
-                  displayName: 'Get Started'
-                }
-              });
-          }])
-          .run( ['installerDataSvc', (installerDataSvc) => {
-            let reqs = installerDataSvc.requirements;
+      $stateProvider
+        .state('account', {
+          url: '/account',
+          controller: 'AccountController as acctCtrl',
+          templateUrl: 'pages/account/account.html'
+        })
+        .state('location', {
+          url: '/location',
+          controller: 'LocationController as locCtrl',
+          templateUrl: 'pages/location/location.html',
+          data: {
+            displayName: 'Target Folder'
+          }
+        })
+        .state('confirm', {
+          url: '/confirm',
+          controller: 'ConfirmController as confCtrl',
+          templateUrl: 'pages/confirm/confirm.html',
+          data: {
+            displayName: 'Confirmation'
+          }
+        })
+        .state('install', {
+          url: '/install',
+          controller: 'InstallController as instCtrl',
+          templateUrl: 'pages/install/install.html',
+          data: {
+            displayName: 'Download & Install'
+          }
+        })
+        .state('start', {
+          url: '/start',
+          controller: 'StartController as startCtrl',
+          templateUrl: 'pages/start/start.html',
+          data: {
+            displayName: 'Get Started'
+          }
+        });
+    }])
+    .run( ['installerDataSvc', (installerDataSvc) => {
+      // filter download-manager urls and replace host name with stage
+      // host name provided in environment variable
+      let stageHost = process.env['DM_STAGE_HOST'];
+      if(stageHost) {
+        for (let variable in reqs) {
+          let dmUrl = reqs[variable]['dmUrl'];
+          if (dmUrl && dmUrl.includes('download-manager/jdf/file')) {
+            reqs[variable].dmUrl = dmUrl.replace('developers.redhat.com', stageHost);
+          }
+        }
+      }
 
-            // filter download-manager urls and replace host name with stage
-            // host name provided in environment variable
-            let stageHost = process.env['DM_STAGE_HOST'];
-            if(stageHost) {
-              for (let variable in reqs) {
-                let dmUrl = reqs[variable]['dmUrl'];
-                if (dmUrl && dmUrl.includes('download-manager/jdf/file')) {
-                  reqs[variable].dmUrl = dmUrl.replace('developers.redhat.com', stageHost);
-                }
-              }
-            }
-
-            let virtualbox = new VirtualBoxInstall(
-              reqs['virtualbox'].version,
-              reqs['virtualbox'].revision,
-              installerDataSvc,
-              reqs['virtualbox'].url,
-              reqs['virtualbox'].filename,
-              'virtualbox',
-              reqs['virtualbox'].sha256sum);
-
-            let cygwin = new CygwinInstall(
-              installerDataSvc,
-              reqs['cygwin'].url,
-              reqs['cygwin'].filename,
-              'cygwin',
-              reqs['cygwin'].sha256sum);
-
-            let cdk = new CDKInstall(
-              installerDataSvc,
-              reqs['cdk'].dmUrl,
-              reqs['cdk'].filename,
-              'cdk',
-              reqs['cdk'].sha256sum
-            );
-
-            let jdk = new JdkInstall(
-              installerDataSvc,
-              reqs['jdk'].dmUrl,
-              reqs['jdk'].filename,
-              reqs['jdk'].prefix,
-              'jdk8',
-              reqs['jdk'].sha256sum);
-
-            let devstudio = new DevstudioInstall(
-              installerDataSvc,
-              reqs['devstudio'].dmUrl,
-              reqs['devstudio'].filename,
-              'developer-studio',
-              reqs['devstudio'].sha256sum);
-
-            let hyperv = new HypervInstall(
-              installerDataSvc,
-              reqs['hyperv'].url
-            );
-
-            installerDataSvc.addItemsToInstall(virtualbox, hyperv, cygwin, cdk, jdk, devstudio);
-
-            jdk.thenInstall(devstudio);
-            jdk.thenInstall(virtualbox).thenInstall(hyperv).thenInstall(cygwin).thenInstall(cdk);
-
-          }]);
+      let loader = new ComponentLoader(installerDataSvc);
+      loader.loadComponents();
+    }]);
 
 export default mainModule;

--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -8,7 +8,7 @@ import Installer from './helpers/installer';
 import globby from 'globby';
 
 class CDKInstall extends InstallableItem {
-  constructor(installerDataSvc, minishiftUrl, fileName, targetFolderName, minishiftSha256) {
+  constructor(installerDataSvc, targetFolderName, minishiftUrl, fileName, minishiftSha256) {
     super(CDKInstall.KEY, minishiftUrl, fileName, targetFolderName, installerDataSvc, true);
 
     this.sha256 = minishiftSha256;
@@ -66,7 +66,7 @@ class CDKInstall extends InstallableItem {
     let newPath = [vboxInstall.getLocation()];
     let oldPath = Platform.ENV[Platform.PATH];
 
-    if (Platform.OS === 'win32') {
+    if (cygwinInstall) {
       newPath.push(cygwinInstall.getLocation());
     }
 

--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -8,7 +8,7 @@ import Util from './helpers/util';
 import Platform from '../services/platform';
 
 class CygwinInstall extends InstallableItem {
-  constructor(installerDataSvc, downloadUrl, fileName, targetFolderName, sha256) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256) {
     super(CygwinInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, false);
     this.cygwinPathScript = path.join(this.installerDataSvc.tempDir(), 'set-cygwin-path.ps1');
     this.addOption('install', this.version, '', true);

--- a/browser/model/devstudio.js
+++ b/browser/model/devstudio.js
@@ -15,7 +15,7 @@ import Util from './helpers/util';
 import Platform from '../services/platform';
 
 class DevstudioInstall extends InstallableItem {
-  constructor(installerDataSvc, downloadUrl, fileName, targetFolderName, devstudioSha256, additionalLocations, additionalIus) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, devstudioSha256, additionalLocations, additionalIus) {
     super(DevstudioInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, true);
 
     this.sha256 = devstudioSha256;

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -13,12 +13,11 @@ import Util from './helpers/util';
 import Version from './helpers/version';
 
 class JdkInstall extends InstallableItem {
-  constructor(installerDataSvc, downloadUrl, fileName, prefix, targetFolderName, jdkSha256) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, jdkSha256) {
     super(JdkInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, true);
     this.sha256 = jdkSha256;
     this.existingVersion = '';
     this.minimumVersion = '1.8.0';
-    this.jdkZipEntryPrefix = prefix;
     this.openJdkMsi = false;
   }
 

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -11,7 +11,7 @@ import Version from './helpers/version';
 import del from 'del';
 
 class VirtualBoxInstall extends InstallableItem {
-  constructor(version, revision, installerDataSvc, downloadUrl, fileName, targetFolderName, sha256) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256, version, revision) {
     super(VirtualBoxInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, false);
 
     this.minimumVersion = version;

--- a/browser/pages/confirm/confirm.html
+++ b/browser/pages/confirm/confirm.html
@@ -17,7 +17,7 @@
   <form name="confirmForm" id="confirmForm" class="form-horizontal" ng-submit="confCtrl.install()" ng-class="{'is-disabled':confCtrl.isDisabled}">
 
     <!-- devstudio -->
-    <div id="devstudio-panel" class="panel panel-default panel2pxborder" ng-class="{'zero-border':checkboxModel.devstudio.hasOption('detected')}">
+    <div id="devstudio-panel" class="panel panel-default panel2pxborder" ng-hide="checkboxModel.devstudio === undefined" ng-class="{'zero-border':checkboxModel.devstudio.hasOption('detected')}">
       <div id="devstudio-panel-heading" class="panel-heading panel-normal"
            ng-class="{'dotted-panel':checkboxModel.devstudio.hasOption('detected')}">
            <!--ng-click="checkboxModel.devstudio.changeIsCollapsed()">-->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- JDK -->
-    <div id="jdk-panel" class="panel panel-default panel2pxborder" ng-class="{'zero-border':checkboxModel.jdk.hasOption('detected')&&checkboxModel.jdk.selectedOption === 'detected' || platform === 'darwin'}">
+    <div id="jdk-panel" class="panel panel-default panel2pxborder" ng-hide="checkboxModel.jdk === undefined" ng-class="{'zero-border':checkboxModel.jdk.hasOption('detected')&&checkboxModel.jdk.selectedOption === 'detected' || platform === 'darwin'}">
       <div id="jdk-panel-heading" class="panel-heading panel-normal"
            ng-class="{'dotted-panel':checkboxModel.jdk.hasOption('detected')&&checkboxModel.jdk.selectedOption === 'detected' || platform === 'darwin'}">
            <!--ng-click="checkboxModel.jdk.changeIsCollapsed()">-->
@@ -184,7 +184,7 @@
     </div>
 
     <!-- CDK -->
-    <div id="cdk-panel" class="panel panel-default panel2pxborder" ng-class="{'zero-border':checkboxModel.cdk.hasOption('detected')}">
+    <div id="cdk-panel" class="panel panel-default panel2pxborder" ng-hide="checkboxModel.cdk === undefined" ng-class="{'zero-border':checkboxModel.cdk.hasOption('detected')}">
       <div id="cdk-panel-heading" class="panel-heading panel-normal"
            ng-class="{'dotted-panel':checkboxModel.cdk.hasOption('detected')}">
            <!--ng-click="checkboxModel.cdk.changeIsCollapsed()">-->
@@ -249,7 +249,7 @@
     </div>
 
     <!-- hyper-v -->
-    <div id="hyperv-panel" class="panel panel-default panel2pxborder" ng-show="checkboxModel.hyperv.isConfigured()" ng-class="{'zero-border':checkboxModel.hyperv.isConfigured()}">
+    <div id="hyperv-panel" class="panel panel-default panel2pxborder" ng-show="checkboxModel.hyperv !== undefined && checkboxModel.hyperv.isConfigured()" ng-class="{'zero-border':checkboxModel.hyperv.isConfigured()}">
       <div id="hyperv-panel-heading" class="panel-heading panel-normal"
            ng-class="{'dotted-panel':checkboxModel.hyperv.hasOption('detected')}">
         <div class="checkbox-container verticalLine">
@@ -268,7 +268,7 @@
     </div>
 
     <!-- VirtualBox -->
-    <div id="virtualbox-panel" class="panel panel-default panel2pxborder" ng-hide="checkboxModel.hyperv.isConfigured()" ng-class="{'zero-border':checkboxModel.virtualbox.hasOption('detected')}">
+    <div id="virtualbox-panel" class="panel panel-default panel2pxborder" ng-hide="checkboxModel.virtualbox === undefined || checkboxModel.hyperv.isConfigured()" ng-class="{'zero-border':checkboxModel.virtualbox.hasOption('detected')}">
       <div id="virtualbox-panel-heading" class="panel-heading panel-normal"
            ng-class="{'dotted-panel':checkboxModel.virtualbox.hasOption('detected')}">
            <!--ng-click="checkboxModel.virtualbox.changeIsCollapsed()">-->
@@ -385,7 +385,7 @@
     </div>
 
     <!-- Cygwin -->
-    <div id="cygwin-panel" class="panel panel-default panel2pxborder" ng-show="platform==='win32'" ng-class="{'zero-border': checkboxModel.cygwin.hasOption('detected') && checkboxModel.cygwin.selectedOption === 'detected'}">
+    <div id="cygwin-panel" class="panel panel-default panel2pxborder" ng-hide="checkboxModel.cygwin === undefined" ng-class="{'zero-border': checkboxModel.cygwin.hasOption('detected') && checkboxModel.cygwin.selectedOption === 'detected'}">
       <div id="cygwin-panel-heading" class="panel-heading panel-normal"
            ng-class="{'dotted-panel':checkboxModel.cygwin.hasOption('detected') && checkboxModel.cygwin.selectedOption === 'detected'}">
            <!--ng-click="checkboxModel.cygwin.changeIsCollapsed()">-->

--- a/browser/services/componentLoader.js
+++ b/browser/services/componentLoader.js
@@ -1,0 +1,97 @@
+'use strict';
+
+import InstallerDataService from './data';
+
+const baseOrder = {
+  'root': ['jdk'],
+  'jdk':  ['virtualbox', 'devstudio'],
+  'virtualbox': ['hyperv'],
+  'hyperv': ['cygwin'],
+  'cygwin': ['cdk'],
+  'devstudio': [],
+  'cdk': []
+};
+
+class ComponentLoader {
+  constructor(installerDataSvc) {
+    this.requirements = installerDataSvc.requirements;
+    this.installerDataSvc = installerDataSvc;
+  }
+
+  loadComponents() {
+    for (let key in this.requirements) {
+      this.addComponent(key);
+    }
+    this.orderInstallation();
+  }
+
+  loadComponent(key) {
+    this.addComponent(key);
+    this.orderInstallation();
+  }
+
+  removeComponent(key) {
+    this.installerDataSvc.allInstallables().delete(key);
+    this.orderInstallation();
+  }
+
+  addComponent(key) {
+    if (this.requirements[key] && this.requirements[key].bundle !== 'tools') {
+      let skippedProperties = ['name', 'description', 'bundle', 'vendor', 'virusTotalReport', 'modulePath'];
+      let args = [this.installerDataSvc];
+      if (this.requirements[key].dmUrl) {
+        skippedProperties.push('url');
+      }
+
+      for (let property in this.requirements[key]) {
+        if (skippedProperties.indexOf(property) < 0) {
+          args.push(this.requirements[key][property]);
+        }
+      }
+      let component = new DynamicClass(this.requirements[key].modulePath, args);
+
+      this.installerDataSvc.addItemToInstall(key, component);
+    }
+  }
+
+  orderInstallation() {
+    let newOrder = {};
+    Object.assign(newOrder, baseOrder);
+    let changed;
+
+    do {
+      changed = false;
+      for (let item of Object.keys(newOrder)) {
+        let children = newOrder[item];
+        let finalChildren = [];
+        for (var i = 0; i < children.length; i++) {
+          if (this.installerDataSvc.getInstallable(children[i])) {
+            finalChildren.push(children[i]);
+          } else {
+            if (newOrder[children[i]]) {
+              finalChildren = finalChildren.concat(newOrder[children[i]]);
+              newOrder[item] = finalChildren;
+              changed = true;
+            }
+          }
+        }
+      }
+    } while (changed)
+
+    for (let [key, value] of this.installerDataSvc.allInstallables()) {
+      for (var i = 0; i < newOrder[key].length; i++) {
+        let nextItem = this.installerDataSvc.getInstallable(newOrder[key][i]);
+        value.thenInstall(nextItem);
+      }
+    }
+  }
+}
+
+class DynamicClass {
+  constructor (modulePath, opts) {
+    let klass = require(`../${modulePath}`);
+    return new klass.default(...opts);
+  }
+}
+
+export default ComponentLoader;

--- a/browser/services/metadata.js
+++ b/browser/services/metadata.js
@@ -1,17 +1,19 @@
 'use strict';
 
 function loadMetadata(requirements, platform) {
+  let reqs = {}
+  Object.assign(reqs, requirements);
   for(var object in requirements) {
-    if(requirements[object].platform) {
-      if(requirements[object].platform[platform]) {
-        Object.assign(requirements[object], requirements[object].platform[platform]);
-        delete requirements[object].platform;
+    if(reqs[object].platform) {
+      if(reqs[object].platform[platform]) {
+        Object.assign(reqs[object], reqs[object].platform[platform]);
+        delete reqs[object].platform;
       } else {
-        delete requirements[object];
+        delete reqs[object];
       }
     }
   }
-  return requirements;
+  return reqs;
 }
 
 module.exports = loadMetadata;

--- a/requirements.json
+++ b/requirements.json
@@ -3,30 +3,32 @@
     "name": "Red Hat Container Development Kit",
     "description": "Developer Tools for Creating, Testing, and Distributing Red Hat Container-Based Applications",
     "vendor": "Red Hat, Inc.",
+    "modulePath": "model/cdk",
+    "targetFolderName": "cdk",
     "platform": {
       "win32": {
         "bundle": "yes",
-        "version": "3.0.0.GA",
         "dmUrl": "http://cdk-builds.usersys.redhat.com/builds/nightly/11-Feb-2017/windows-amd64/minishift.exe",
         "url": "http://cdk-builds.usersys.redhat.com/builds/nightly/11-Feb-2017/windows-amd64/minishift.exe",
         "filename": "minishift.exe",
-        "sha256sum": "984318638a5c0d67ae4483bb508f6b90b99f885153dc525660bfff07fa883c94"
+        "sha256sum": "984318638a5c0d67ae4483bb508f6b90b99f885153dc525660bfff07fa883c94",
+        "version": "3.0.0.GA"
       },
       "darwin": {
         "bundle": "yes",
-        "version": "3.0.0.GA",
         "dmUrl": "http://cdk-builds.usersys.redhat.com/builds/nightly/11-Feb-2017/darwin-amd64/minishift",
         "url": "http://cdk-builds.usersys.redhat.com/builds/nightly/11-Feb-2017/darwin-amd64/minishift",
         "filename": "minishift",
-        "sha256sum": "1e7472175e25d9d197149a3ed2192440a1f581f1884cf2b2c77d97674ee73e5e"
+        "sha256sum": "1e7472175e25d9d197149a3ed2192440a1f581f1884cf2b2c77d97674ee73e5e",
+        "version": "3.0.0.GA"
       },
       "linux": {
         "bundle": "yes",
-        "version": "3.0.0.GA",
         "dmUrl": "http://cdk-builds.usersys.redhat.com/builds/nightly/11-Feb-2017/linux-amd64/minishift",
         "url": "http://cdk-builds.usersys.redhat.com/builds/weekly/25-Jan-2017.3.0_alpha.2/linux-amd64/minishift",
         "filename": "linux-amd64.tar.gz",
-        "sha256sum": "76da07d4065eb387093af1316371a19c11982b4b9270eff14bca84db69e2bb32"
+        "sha256sum": "76da07d4065eb387093af1316371a19c11982b4b9270eff14bca84db69e2bb32",
+        "version": "3.0.0.GA"
       }
     }
   },
@@ -34,55 +36,64 @@
     "name": "Cygwin",
     "description": "A distribution of popular GNU and other Open Source tools running on Microsoft Windows",
     "vendor": "Community Project",
+    "modulePath": "model/cygwin",
     "bundle": "always",
-    "version": "2.6.1",
+    "targetFolderName": "cygwin",
     "url": "https://cygwin.com/setup-x86_64.exe",
     "filename": "cygwin_2.6.1.exe",
     "sha256sum": "b67afe083b2547acee0857b45ff9784f873d1fb226a0148c1364f255180fc282",
-    "virusTotalReport": "https://virustotal.com/en/file/446b658bc1b8b6c7865474188cb4d7e9873003e2b6a9d74dcdfb7a3ff77e8634/analysis/"
+    "version": "2.6.1",
+    "virusTotalReport": "https://virustotal.com/en/file/446b658bc1b8b6c7865474188cb4d7e9873003e2b6a9d74dcdfb7a3ff77e8634/analysis/",
+    "platform": {
+      "win32": {}
+    }
   },
   "devstudio": {
     "name": "Red Hat JBoss Developer Studio",
     "description": "A certified Eclipse-based integrated development environment (IDE)",
     "vendor": "Red Hat, Inc.",
+    "modulePath": "model/devstudio",
     "bundle": "yes",
-    "version": "10.4.0.AM1",
+    "targetFolderName": "developer-studio",
     "dmUrl": "https://devstudio.redhat.com/10.0/staging/builds/devstudio-10.4.0.AM1-build-product/latest/all/devstudio-10.4.0.AM1-v20170309-1919-B213-installer-standalone.jar",
     "url": "https://devstudio.redhat.com/10.0/staging/builds/devstudio-10.4.0.AM1-build-product/latest/all/devstudio-10.4.0.AM1-v20170309-1919-B213-installer-standalone.jar",
     "filename": "devstudio-10.4.0.AM1-v20170309-1919-B213-installer-standalone.jar",
-    "sha256sum": "bd111c8a7d73a87fc35523b95b37d75147be562a6226c242b613cb639a1a27eb"
+    "sha256sum": "bd111c8a7d73a87fc35523b95b37d75147be562a6226c242b613cb639a1a27eb",
+    "version": "10.4.0.AM1"
   },
   "jdk": {
     "name": "OpenJDK",
     "description": "A free and open source implementation of the Java Platform, Standard Edition (Java SE)",
     "vendor": "Red Hat, Inc.",
+    "modulePath": "model/jdk-install",
+    "targetFolderName": "jdk8",
     "platform": {
       "win32": {
         "bundle": "yes",
-        "version": "1.8.0_121",
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/java-1.8.0-openjdk-1.8.0.121-1.b13.redhat.windows.x86_64.msi?workflow=direct",
         "url": "http://download.eng.bos.redhat.com/brewroot/packages/openjdk8-win/1.8.0.121/1.b13/win/java-1.8.0-openjdk-1.8.0.121-1.b13.redhat.windows.x86_64.msi",
         "filename": "java-1.8.0-openjdk-1.8.0.121-1.b13.redhat.windows.x86_64.msi",
         "sha256sum": "de5ea4e373cc913fa89942800998d92fb926f29ae393a2d24a9140a1d821e611",
+        "version": "1.8.0_121",
         "virusTotalReport": "https://virustotal.com/en/file/de5ea4e373cc913fa89942800998d92fb926f29ae393a2d24a9140a1d821e611/analysis/"
       },
       "darwin": {
         "bundle": "no",
-        "version": "1.8.0_111",
         "prefix": "java-1.8.0-openjdk-1.8.0",
         "dmUrl": "http://www.oracle.com/technetwork/java/javase/downloads/index.html",
         "url": "http://www.oracle.com/technetwork/java/javase/downloads/index.html",
         "filename": "jdk-8u111-macosx-x64.dmg",
         "sha256sum": "",
+        "version": "1.8.0_111",
         "virusTotalReport": ""
       },
       "linux": {
         "bundle": "yes",
-        "version": "1.8.0_111",
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/java-1.8.0-openjdk-1.8.0.111-1.b15.redhat.windows.x86_64.msi?workflow=direct",
         "url": "http://download-node-02.eng.bos.redhat.com/brewroot/packages/openjdk8-win/1.8.0.111/1.b15/win/java-1.8.0-openjdk-1.8.0.111-1.b15.redhat.windows.x86_64.msi",
         "filename": "java-1.8.0-openjdk-1.8.0.111-1.b15.redhat.windows.x86_64.msi",
         "sha256sum": "fc4c77412446d6bbf6bf91d76d4bb5cf5d1e94dc1e932f524796e3f8a9789ccc",
+        "version": "1.8.0_111",
         "virusTotalReport": "https://virustotal.com/en/file/fc4c77412446d6bbf6bf91d76d4bb5cf5d1e94dc1e932f524796e3f8a9789ccc/analysis/"
       }
     }
@@ -91,32 +102,34 @@
     "name": "Oracle VirtualBox",
     "description": "A virtualization software package developed by Oracle",
     "vendor": "Oracle, Inc.",
+    "modulePath": "model/virtualbox",
+    "targetFolderName": "virtualbox",
     "platform": {
       "win32": {
         "bundle": "no",
-        "version": "5.1.12",
-        "revision": "112440",
         "url": "http://download.virtualbox.org/virtualbox/5.1.12/VirtualBox-5.1.12-112440-Win.exe",
         "filename": "virtualbox_5.1.12.exe",
         "sha256sum": "0cbdc245122fab090625bb3ec49f21f68c9bbad7d69e05e4a42b1a6ad1968b54",
+        "version": "5.1.12",
+        "revision": "112440",
         "virusTotalReport": "https://virustotal.com/en/file/0cbdc245122fab090625bb3ec49f21f68c9bbad7d69e05e4a42b1a6ad1968b54/analysis/"
       },
       "darwin": {
         "bundle": "no",
-        "version": "5.1.12",
-        "revision": "112440",
         "url": "http://download.virtualbox.org/virtualbox/5.1.12/VirtualBox-5.1.12-112440-OSX.dmg",
         "filename": "virtualbox_5.1.12.dmg",
         "sha256sum": "74b10d9af01b8eb7d987088ffe52c74646a479a27cba4f98dc5149f1f6b93c76",
+        "version": "5.1.12",
+        "revision": "112440",
         "virusTotalReport": "https://virustotal.com/en/file/74b10d9af01b8eb7d987088ffe52c74646a479a27cba4f98dc5149f1f6b93c76/analysis/"
       },
       "linux": {
         "bundle": "no",
-        "version": "5.1.12",
-        "revision": "112440",
         "url": "http://download.virtualbox.org/virtualbox/5.1.12/VirtualBox-5.1-5.1.12_112440_fedora25-1.x86_64.rpm",
         "filename": "VirtualBox-5.1-5.1.12_112440_fedora25-1.x86_64.rpm",
         "sha256sum": "4a97ca581f4aa4e8fc442d60c2cde214c52808bf6e24b28e0574bea22176c76c",
+        "version": "5.1.12",
+        "revision": "112440",
         "virusTotalReport": "https://virustotal.com/en/file/4a97ca581f4aa4e8fc442d60c2cde214c52808bf6e24b28e0574bea22176c76c/analysis/"
       }
     }
@@ -124,14 +137,18 @@
   "hyperv": {
     "name": "Microsoft Hyper-V",
     "description": "Microsoft Windows Virtualization Platform",
+    "modulePath": "model/hyperv",
     "bundle": "no",
-    "version": "",
-    "revision": "112440",
     "url": "https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/",
     "filename": "",
     "sha256sum": "",
+    "version": "",
+    "revision": "112440",
     "virusTotalReport": "",
-    "vendor": "Microsoft, Inc."
+    "vendor": "Microsoft, Inc.",
+    "platform": {
+      "win32": {}
+    }
   },
   "7zip": {
     "name": "7zip",

--- a/test/unit/model/devstudio-test.js
+++ b/test/unit/model/devstudio-test.js
@@ -75,7 +75,7 @@ describe('devstudio installer', function() {
   });
 
   beforeEach(function () {
-    installer = new DevstudioInstall(installerDataSvc, downloadUrl, 'devstudio.jar', 'dev-studio', 'sha' );
+    installer = new DevstudioInstall(installerDataSvc, 'dev-studio', downloadUrl, 'devstudio.jar', 'sha');
     installer.ipcRenderer = { on: function() {} };
     sandbox = sinon.sandbox.create();
     fakeProgress = sandbox.stub(new ProgressState());
@@ -87,18 +87,18 @@ describe('devstudio installer', function() {
 
   it('should fail when no url is set and installed file not defined', function() {
     expect(function() {
-      new DevstudioInstall(installerDataSvc, null, null);
+      new DevstudioInstall(installerDataSvc, null, null, null);
     }).to.throw('No download URL set');
   });
 
   it('should fail when no url is set and installed file is empty', function() {
     expect(function() {
-      new DevstudioInstall(installerDataSvc, null, '');
+      new DevstudioInstall(installerDataSvc, null, null, '');
     }).to.throw('No download URL set');
   });
 
   it('should download devstudio installer to temporary folder with configured filename', function() {
-    expect(new DevstudioInstall(installerDataSvc, 'url', 'devstudio.jar').downloadedFile).to.equal(
+    expect(new DevstudioInstall(installerDataSvc, 'dev-studio', 'url', 'devstudio.jar').downloadedFile).to.equal(
       path.join('tempDirectory', 'devstudio.jar'));
   });
 

--- a/test/unit/model/virtualbox-test.js
+++ b/test/unit/model/virtualbox-test.js
@@ -67,7 +67,7 @@ describe('Virtualbox installer', function() {
   });
 
   beforeEach(function () {
-    installer = new VirtualBoxInstall(version, revision, installerDataSvc, downloadUrl, 'virtualbox.exe', 'virtualbox', 'sha');
+    installer = new VirtualBoxInstall(installerDataSvc, 'virtualbox', downloadUrl, 'virtualbox.exe', 'sha', version, revision);
     installer.ipcRenderer = { on: function() {} };
     sandbox = sinon.sandbox.create();
     fakeProgress = sandbox.stub(new ProgressState());
@@ -79,18 +79,18 @@ describe('Virtualbox installer', function() {
 
   it('should fail when no url is set and installed file not defined', function() {
     expect(function() {
-      new VirtualBoxInstall('ver', 'rev', installerDataSvc, null, null);
+      new VirtualBoxInstall(installerDataSvc, null, null, null, null, 'ver', 'rev');
     }).to.throw('No download URL set');
   });
 
   it('should fail when no url is set and installed file is empty', function() {
     expect(function() {
-      new VirtualBoxInstall('ver', 'rev', installerDataSvc, null, '');
+      new VirtualBoxInstall(installerDataSvc, null, null, '', null, 'ver', 'rev');
     }).to.throw('No download URL set');
   });
 
   it('should download virtualbox installer to temporary folder with name configured file name', function() {
-    expect(new VirtualBoxInstall('ver', 'rev', installerDataSvc, 'url', 'virtualbox.exe', 'virtualbox', 'sha').downloadedFile).to.equal(
+    expect(new VirtualBoxInstall(installerDataSvc, 'virtualbox', 'url', 'virtualbox.exe', 'sha', 'ver', 'rev').downloadedFile).to.equal(
       path.join(installerDataSvc.tempDir(), 'virtualbox.exe'));
   });
 
@@ -141,7 +141,7 @@ describe('Virtualbox installer', function() {
       beforeEach(function() {
         helper = new Installer('virtualbox', fakeProgress);
         sandbox.stub(Platform, 'getOS').returns('macOS');
-        installer = new VirtualBoxInstallWindows(version, revision, installerDataSvc, downloadUrl, 'virtualbox.exe', 'virtualbox', 'sha');
+        installer = new VirtualBoxInstallDarwin(installerDataSvc, 'virtualbox', downloadUrl, 'virtualbox.exe', 'sha', version, revision);
         installer.ipcRenderer = {on: function() {}};
       });
     });
@@ -150,7 +150,7 @@ describe('Virtualbox installer', function() {
       beforeEach(function() {
         helper = new Installer('virtualbox', fakeProgress);
         sandbox.stub(Platform, 'getOS').returns('win32');
-        installer = new VirtualBoxInstallWindows(version, revision, installerDataSvc, downloadUrl, 'virtualbox.exe', 'virtualbox', 'sha');
+        installer = new VirtualBoxInstallWindows(installerDataSvc, 'virtualbox', downloadUrl, 'virtualbox.exe', 'sha', version, revision);
         installer.ipcRenderer = {on: function() {}};
       });
 
@@ -325,7 +325,7 @@ describe('Virtualbox installer', function() {
         stub.onCall(1).resolves(VERSION);
 
         sandbox.stub(Util, 'folderContains').resolves(LOCATION);
-        installer = new VirtualBoxInstallDarwin(version, revision, installerDataSvc, downloadUrl, 'virtualbox.exe', 'virtualbox', 'sha');
+        installer = new VirtualBoxInstallDarwin(installerDataSvc, 'virtualbox', downloadUrl, 'virtualbox.exe', 'sha', version, revision);
         validateStub = sandbox.stub(installer, 'validateVersion').returns();
       });
 
@@ -349,7 +349,7 @@ describe('Virtualbox installer', function() {
         stub.onCall(2).resolves(VERSION);
 
         sandbox.stub(Util, 'folderContains').resolves(LOCATION);
-        installer = new VirtualBoxInstallWindows(version, revision, installerDataSvc, downloadUrl, 'virtualbox.exe', 'virtualbox', 'sha');
+        installer = new VirtualBoxInstallWindows(installerDataSvc, 'virtualbox', downloadUrl, 'virtualbox.exe', 'sha', version, revision);
         validateStub = sandbox.stub(installer, 'validateVersion').returns();
       });
 

--- a/test/unit/pages/confirm/controller-test.js
+++ b/test/unit/pages/confirm/controller-test.js
@@ -75,24 +75,6 @@ describe('ConfirmController', function() {
         });
       });
     });
-
-
-    describe('on macos', function() {
-      beforeEach(function() {
-        sandbox.stub(Platform, 'getOS').returns('darwin');
-      });
-      beforeEach(inject(context));
-      it('does not count cygwin as detected component', function() {
-        return new Promise(function(resolve) {
-          confirmController.sc.$apply = function() {
-            resolve();
-          };
-          $scope.$digest();
-        }).then(function() {
-          expect(confirmController.numberOfExistingInstallations).to.be.equal(0);
-        });
-      });
-    });
   });
 
   beforeEach(function() {

--- a/test/unit/pages/install/controller-test.js
+++ b/test/unit/pages/install/controller-test.js
@@ -39,8 +39,8 @@ describe('Install controller', function() {
     sandbox.stub(InstallerDataService.prototype, 'copyUninstaller').returns();
     installerDataSvc = new InstallerDataService();
     installerDataSvc.setup('installRoot');
-    vbox = new VirtualBoxInstall('5.0.8', '103449', installerDataSvc,
-      'http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}-${revision}-Win.exe', 'virtualbox.exe', 'virtualbox', 'sha');
+    vbox = new VirtualBoxInstall(installerDataSvc, 'virtualbox',
+      'http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}-${revision}-Win.exe', 'virtualbox.exe', 'sha', '5.0.8', '103449');
 
     installerDataSvc.addItemToInstall(VirtualBoxInstall.KEY, vbox);
   });

--- a/test/unit/pages/start/controller-test.js
+++ b/test/unit/pages/start/controller-test.js
@@ -42,7 +42,7 @@ describe('StartController', function() {
     });
   });
 
-  describe('lernCDK', function() {
+  describe('learnCDK', function() {
     it('opens external url ' + StartController.LEARN_CDK_URL, function() {
       let electron = new ElectronMock();
       sandbox.stub(electron.shell, 'openExternal');

--- a/test/unit/services/componentLoader-test.js
+++ b/test/unit/services/componentLoader-test.js
@@ -1,0 +1,234 @@
+'use strict';
+
+import chai, { expect } from 'chai';
+import InstallerDataService from 'browser/services/data';
+import ComponentLoader from 'browser/services/componentLoader';
+
+describe('Component Loader', function() {
+  let svc, loader;
+  let reqs = {
+    'cdk': {
+      name: 'cdk',
+      modulePath: 'model/cdk',
+      targetFolderName: 'cdkFolder',
+      bundle: 'yes',
+      dmUrl: 'cdkDmUrl',
+      url: 'cdkUrl',
+      filename: 'minishift.exe',
+      sha256sum: 'cdkSHA',
+      version: '3.0.0.GA'
+    },
+    'jdk': {
+      name: 'jdk',
+      modulePath: 'model/jdk-install',
+      targetFolderName: 'jdkFolder',
+      bundle: 'yes',
+      dmUrl: 'jdkDmUrl',
+      url: 'jdkUrl',
+      filename: 'jdk.msi',
+      sha256sum: 'jdkSHA',
+      version: '1.8.0'
+    },
+    'devstudio': {
+      name: 'devstudio',
+      modulePath: 'model/devstudio',
+      targetFolderName: 'devstudioFolder',
+      bundle: 'yes',
+      url: 'devstudioUrl',
+      dmUrl: 'devstudioDmUrl',
+      filename: 'devstudio.jar',
+      sha256sum: 'devstudioSHA',
+      version: '10.4.0'
+    },
+    'cygwin': {
+      name: 'cygwin',
+      modulePath: 'model/cygwin',
+      targetFolderName: 'cygwinFolder',
+      bundle: 'always',
+      url: 'cygwinUrl',
+      filename: 'cygwin.exe',
+      sha256sum: 'cygwinSHA',
+      version: '2.7.0'
+    },
+    'virtualbox': {
+      name: 'virtualbox',
+      modulePath: 'model/virtualbox',
+      targetFolderName: 'virtualboxFolder',
+      bundle: 'no',
+      url: 'virtualboxUrl',
+      filename: 'virtualbox.exe',
+      sha256sum: 'virtualboxSHA',
+      version: '5.1.12'
+    },
+    '7zip': {
+      name: '7zip',
+      bundle: 'tools',
+      url: '7zipUrl',
+      filename: '7zip.exe',
+      sha256sum: '7zipSHA',
+      version: '1.0.0'
+    }
+  };
+  let reducedReqs = {};
+  let reducedReqs2 = {};
+  Object.assign(reducedReqs, reqs);
+  Object.assign(reducedReqs2, reqs);
+  delete reducedReqs.jdk;
+  delete reducedReqs2.cygwin;
+
+  describe('addComponent', function() {
+
+    beforeEach(function() {
+      svc = new InstallerDataService({}, reqs);
+      loader = new ComponentLoader(svc);
+    });
+
+    it('should add a non-tool component', function() {
+      loader.addComponent('cdk');
+      expect(svc.getInstallable('cdk')).to.not.equal(undefined);
+    });
+
+    it('should not add a tool component', function() {
+      loader.addComponent('7zip');
+      expect(svc.getInstallable('7zip')).to.equal(undefined);
+    });
+
+    it('should ignore url property when dmUrl is present', function() {
+      loader.addComponent('cdk');
+      expect(svc.getInstallable('cdk').downloadUrl).to.equal('cdkDmUrl');
+    });
+
+    it('should create the component with the appropriate properties', function() {
+      loader.addComponent('cdk');
+      let cdk = svc.getInstallable('cdk');
+
+      expect(cdk.keyName).to.equal('cdk');
+      expect(cdk.targetFolderName).to.equal('cdkFolder');
+      expect(cdk.downloadUrl).to.equal('cdkDmUrl');
+      expect(cdk.bundledFile).to.contain('minishift.exe');
+      expect(cdk.sha256).to.equal('cdkSHA');
+    });
+  });
+
+  describe('orderInstallation', function() {
+    it('should respect the default order if no component is missing', function() {
+      svc = new InstallerDataService({}, reqs);
+      loader = new ComponentLoader(svc);
+      addAll(loader, reqs);
+      loader.orderInstallation();
+
+      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
+      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
+    });
+
+    it('if the first component in sequence is not present, its children should take its place', function() {
+      svc = new InstallerDataService({}, reducedReqs);
+      loader = new ComponentLoader(svc);
+      addAll(loader, reducedReqs);
+      loader.orderInstallation();
+
+      expect(svc.getInstallable('jdk')).to.equal(undefined);
+      expect(svc.getInstallable('devstudio').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('virtualbox').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
+      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
+    });
+
+    it('should squash the install sequence if some component not present', function() {
+      svc = new InstallerDataService({}, reducedReqs2);
+      loader = new ComponentLoader(svc);
+      addAll(loader, reducedReqs2);
+      loader.orderInstallation();
+
+      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('cygwin')).to.equal(undefined);
+      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('virtualbox');
+    })
+  });
+
+  describe('removeComponent', function() {
+    beforeEach(function() {
+      svc = new InstallerDataService({}, reqs);
+      loader = new ComponentLoader(svc);
+      addAll(loader, reqs);
+      loader.orderInstallation();
+    });
+
+    it('should delete the appropriate component', function() {
+      loader.removeComponent('cdk');
+      expect(svc.getInstallable('cdk')).to.be.undefined;
+    });
+
+    it('should rearange the installation sequence', function() {
+      loader.removeComponent('cygwin');
+
+      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('cygwin')).to.equal(undefined);
+      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('virtualbox');
+    });
+  });
+
+  describe('loadComponent', function() {
+    beforeEach(function() {
+      svc = new InstallerDataService({}, reqs);
+      loader = new ComponentLoader(svc);
+      addAll(loader, reducedReqs);
+      loader.orderInstallation();
+    });
+
+    it('should add the specified component', function() {
+      loader.loadComponent('jdk');
+      expect(svc.getInstallable('jdk')).to.not.equal(undefined);
+    });
+
+    it('should rearange the installation sequence', function() {
+      loader.loadComponent('jdk')
+
+      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
+      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
+    });
+  });
+
+  describe('loadComponents', function() {
+    beforeEach(function() {
+      svc = new InstallerDataService({}, reqs);
+      loader = new ComponentLoader(svc);
+    });
+
+    it('should add all the components from the requirements', function() {
+      loader.loadComponents();
+
+      expect(svc.getInstallable('jdk')).to.not.equal(undefined);
+      expect(svc.getInstallable('devstudio')).to.not.equal(undefined);
+      expect(svc.getInstallable('virtualbox')).to.not.equal(undefined);
+      expect(svc.getInstallable('cygwin')).to.not.equal(undefined);
+      expect(svc.getInstallable('cdk')).to.not.equal(undefined);
+    });
+
+    it('should order the installation sequence', function() {
+      loader.loadComponents()
+
+      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
+      expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
+      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
+    });
+  });
+});
+
+function addAll(loader, requirements) {
+  for (let key in requirements) {
+    loader.addComponent(key);
+  }
+}

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -28,8 +28,8 @@ describe('InstallerDataService', function() {
     };
     sandbox = sinon.sandbox.create();
     jdk = new InstallableItem('jdk', 'https://domain.com/jdk.msi', 'jdk.msi', 'jdk', svc);
-    vbox = new VirtualBoxInstall('5.0.8', '103449', svc,
-      'http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}-${revision}-Win.exe', 'virtualbox.exe', 'virtualbox', 'sha');
+    vbox = new VirtualBoxInstall(svc, 'virtualbox',
+      'http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}-${revision}-Win.exe', 'virtualbox.exe', 'sha', '5.0.8', '103449');
   });
 
   afterEach(function() {
@@ -85,7 +85,8 @@ describe('InstallerDataService', function() {
     it('should set requirements to provided in requirements parameter', function() {
       let requirements = {'cdk.zip':{'url':'http.redhat.com'}};
       let svc = new InstallerDataService(undefined, requirements);
-      expect(svc.requirements).to.be.equal(requirements);
+
+      expect(svc.requirements).to.deep.equal(requirements);
     });
 
     it('should set default values correctly', function() {


### PR DESCRIPTION
Rewritten the hardcoded init for model classes into something more "dynamic". Quite a big change, so here is how it works:
 - everything (almost) is now loaded from requirements.json - it maps strings to class names and instantiates them using javascript magic (see ComponentLoader and DynamicClass for reference)
 - there is some default ordering of the installation sequence if all the components are present
 - if some component is omitted, the loader squashes the sequence = replaces the component with the components that depended on it (e.g. if cygwin is omitted, cdk installs after virtualbox/hyper-v), the same principle is used for the checkboxModel in confirmController
 - the model constructors are fed arguments directly from requirements.json, therefore the ordering of the properties in requirements.json now matters
   - if a new argument to a constructor is needed, it should be appended to the end of the argument list
 - confirm page now only shows components that are instantiated
 - moved some requirements exclusively to their respective platforms (like cygwin)
 - one of virtualbox/hyper-v is now removed from components upon clicking "install" depending on what option is available. I tried to do this sooner, but then they would need to be re-added if the user changed the settings and detection was run again