### PR TITLE
Add ability to debug tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "package-simple": "./node_modules/.bin/gulp package-simple",
     "coverage:publish": "codecov",
     "dist": "./node_modules/.bin/gulp dist",
+    "debug-test": "NODE_PATH=. node node_modules/.bin/mocha --inspect --debug-brk --compilers=js:babel-core/register --recursive",
     "test": "./node_modules/.bin/gulp test",
     "ui-test": "./node_modules/.bin/gulp ui-test",
     "system-test": "./node_modules/.bin/gulp system-test",


### PR DESCRIPTION
Add

``` JavaScript
debugger;
```

line in your tests where you want to start debugging and run

``` Shell

npm run debug-test test/unit/

```

Then open url printed in stdout in browser and hit run button in
Devtools toolbar.