### PR TITLE
Java detection does not work under linux

### DIFF
--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -110,7 +110,7 @@ class JdkInstall extends InstallableItem {
     let data = this.getMsiSearchScriptData();
     let args = this.getMsiSearchScriptPowershellArgs(msiSearchScript);
     let result = Promise.resolve('');
-    if (Platform.OS !== 'darwin') {
+    if (Platform.OS == 'win32') {
       result = Util.writeFile(msiSearchScript, data).then(()=>{
         return Util.executeFile('powershell', args);
       });


### PR DESCRIPTION
Fix skips msi detection for linux and darwin platforms