### PR TITLE
JBDS-4301 Print login error to chromium console

### DIFF
--- a/browser/pages/account/controller.js
+++ b/browser/pages/account/controller.js
@@ -97,6 +97,7 @@ class AccountController {
     this.authFailed = false;
     this.isLoginBtnClicked = false;
     this.httpError = error;
+    console.error(error);
     this.apply();
   }
 


### PR DESCRIPTION
This fix is temporary solution for cases when there are
problems with proxy configuration. There is no log file yet
so let's out it as error to chromium console.