### PR TITLE
Update devstudio link + remove duplicated build steps

### DIFF
--- a/gulp-tasks/dist-darwin.js
+++ b/gulp-tasks/dist-darwin.js
@@ -62,19 +62,7 @@ function darwinDist(gulp) {
   });
 
   gulp.task('dist', function() {
-    return runSequence('clean', 'check-requirements', 'update-package', 'dist-simple', 'dist-bundle', 'cleanup');
-  });
-
-  gulp.task('update-package', ['update-requirements'], function() {
-    return new Promise((resolve, reject)=>{
-      fs.writeFile('./transpiled/package.json', JSON.stringify(pjson, null, 2), function(error) {
-        if(error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
-    });
+    return runSequence('clean', 'check-requirements', 'update-requirements', 'dist-simple', 'dist-bundle', 'cleanup');
   });
 
   gulp.task('dist-bundle', ['prefetch'], function() {

--- a/gulp-tasks/dist-win32.js
+++ b/gulp-tasks/dist-win32.js
@@ -78,18 +78,18 @@ module.exports = function(gulp) {
 
   // Create stub installer that will then download all the requirements
   gulp.task('package-simple', function(cb) {
-    runSequence(['check-requirements', 'clean'], 'create-dist-dir', 'update-requirements', ['generate',
+    runSequence(['check-requirements', 'clean'], 'create-dist-dir', ['generate',
       'prepare-tools'], 'prefetch-cygwin', 'package', 'cleanup', cb);
   });
 
   gulp.task('package-bundle', function(cb) {
-    runSequence(['check-requirements', 'clean'], 'create-dist-dir', 'update-requirements', ['generate',
+    runSequence(['check-requirements', 'clean'], 'create-dist-dir', ['generate',
       'prepare-tools'], 'prefetch', 'prefetch-cygwin-packages', 'package', 'cleanup', cb);
   });
 
   // Create both installers
   gulp.task('dist', function(cb) {
-    runSequence(['check-requirements', 'clean'], 'create-dist-dir', 'update-requirements', ['generate',
+    runSequence(['check-requirements', 'clean'], 'create-dist-dir', ['generate',
       'prepare-tools'], 'prefetch-cygwin', 'package', 'prefetch', 'prefetch-cygwin-packages', 'package', 'cleanup', cb);
   });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,7 +96,7 @@ gulp.task('update-requirements', ['transpile:app'], function() {
 
   let updateDevStudioVersion = ()=>{
     return new Promise((resolve, reject) => {
-      let url = reqs['devstudio'].url.substring(0, reqs['devstudio'].url.lastIndexOf('/')) + '/content.json';
+      let url = reqs['devstudio'].url + '/content.json';
       request(url, (err, response, body)=>{
         if (err) {
           reject(err);

--- a/requirements.json
+++ b/requirements.json
@@ -55,8 +55,8 @@
     "modulePath": "model/devstudio",
     "bundle": "yes",
     "targetFolderName": "developer-studio",
-    "dmUrl": "https://devstudio.redhat.com/11/staging/builds/devstudio-11.0.0.AM1-build-product/2017-06-01_13-56-01-B198/all/devstudio-11.0.0.AM1-v20170601-1252-B198-installer-standalone.jar",
-    "url": "https://devstudio.redhat.com/11/staging/builds/devstudio-11.0.0.AM1-build-product/2017-06-01_13-56-01-B198/all/devstudio-11.0.0.AM1-v20170601-1252-B198-installer-standalone.jar",
+    "dmUrl": "https://devstudio.redhat.com/11/snapshots/builds/devstudio.product_master/latest/all/",
+    "url": "https://devstudio.redhat.com/11/snapshots/builds/devstudio.product_master/latest/all/",
     "filename": "devstudio-11.0.0.AM1-installer-standalone.jar",
     "sha256sum": "",
     "version": "11.0.0.AM1"

--- a/requirements.json
+++ b/requirements.json
@@ -55,8 +55,8 @@
     "modulePath": "model/devstudio",
     "bundle": "yes",
     "targetFolderName": "developer-studio",
-    "dmUrl": "http://wonka.mw.lab.eng.bos.redhat.com/rhd/devstudio/11/snapshots/builds/devstudio.product_master/2017-06-02_23-46-56-B210/all/devstudio-11.0.0.AM1-v20170602-2254-B210-installer-standalone.jar",
-    "url": "http://wonka.mw.lab.eng.bos.redhat.com/rhd/devstudio/11/snapshots/builds/devstudio.product_master/2017-06-02_23-46-56-B210/all/devstudio-11.0.0.AM1-v20170602-2254-B210-installer-standalone.jar",
+    "dmUrl": "https://devstudio.redhat.com/11/staging/builds/devstudio-11.0.0.AM1-build-product/2017-06-01_13-56-01-B198/all/devstudio-11.0.0.AM1-v20170601-1252-B198-installer-standalone.jar",
+    "url": "https://devstudio.redhat.com/11/staging/builds/devstudio-11.0.0.AM1-build-product/2017-06-01_13-56-01-B198/all/devstudio-11.0.0.AM1-v20170601-1252-B198-installer-standalone.jar",
     "filename": "devstudio-11.0.0.AM1-installer-standalone.jar",
     "sha256sum": "",
     "version": "11.0.0.AM1"


### PR DESCRIPTION
 - Something/someone keeps deleting devstudio builds from the staging server.
 - update-requirements was called twice in most cases, update-package on mac is now part of update-requirements, so I deleted that one as well