### PR TITLE
JBDS-4420 Clarify Java instructions for Mac

### DIFF
--- a/browser/pages/confirm/confirm.html
+++ b/browser/pages/confirm/confirm.html
@@ -182,17 +182,17 @@
 
     <div class="message-container error-message" ng-show="!checkboxModel.jdk.isConfigured() && checkboxModel.devstudio.selectedOption == 'install' && platform === 'win32'">
       <span class="pficon pficon-error-circle-o"></span>
-      <span>You are required to install OpenJDK because you've selected Red Hat JBoss Developer Studio and that requires Java VM version 1.8.0 or higher to run installation.</span>
+      <span>You are required to install OpenJDK because you have selected Red Hat JBoss Developer Studio and that requires Java VM version 1.8.0 or higher to run installation.</span>
     </div>
     <div class="message-container error-message" ng-show="!confCtrl.isDisabled && checkboxModel.jdk.isInvalidVersionDetected() && checkboxModel.devstudio.selectedOption == 'install' && platform == 'darwin'">
       <span class="pficon pficon-error-circle-o"></span>
-      <span>You've selected Red Hat JBoss Developer Studio and that requires Java SE version 1.8.0 or higher to run installation.
-        Please uninstall detected Java SE, install version {{checkboxModel.jdk.minimumVersion}} downloaded from <a type="button" class="pointer" ng-click="confCtrl.download(checkboxModel.jdk.downloadUrl)">this location</a> and retart Installer to continue.</span>
+      <span>You have selected Red Hat JBoss Developer Studio which requires Java SE version {{checkboxModel.jdk.minimumVersion}} or higher to run installation. Due to licence limitations we may not install Java for you.
+        Please uninstall detected Java SE, install JDK version {{checkboxModel.jdk.minimumVersion}} downloaded from <a type="button" class="pointer" ng-click="confCtrl.download(checkboxModel.jdk.downloadUrl)">this location</a> and restart Installer to continue.</span>
     </div>
     <div class="message-container error-message" ng-show="!confCtrl.isDisabled && checkboxModel.jdk.isNotDetected() && checkboxModel.devstudio.selectedOption == 'install' && platform == 'darwin'">
       <span class="pficon pficon-error-circle-o"></span>
-      <span>You've selected Red Hat JBoss Developer Studio and that requires Java SE version 1.8.0 or higher to run installation.
-        Please install  Java SE {{checkboxModel.jdk.minimumVersion}} downloaded from <a type="button" class="pointer" ng-click="confCtrl.download(checkboxModel.jdk.downloadUrl)">this location</a> and retart Installer to continue.</span>
+      <span>You have selected Red Hat JBoss Developer Studio which requires Java SE version {{checkboxModel.jdk.minimumVersion}} or higher to run installation. Due to licence limitations we may not install Java for you.
+        Please install JDK {{checkboxModel.jdk.minimumVersion}} downloaded from <a type="button" class="pointer" ng-click="confCtrl.download(checkboxModel.jdk.downloadUrl)">this location</a> and restart Installer to continue.</span>
     </div>
 
     <!-- CDK -->

--- a/requirements.json
+++ b/requirements.json
@@ -75,13 +75,13 @@
     "version": "7.0.0.GA"
   },
   "jdk": {
-    "name": "OpenJDK",
     "description": "A free and open source implementation of the Java Platform, Standard Edition (Java SE)",
     "vendor": "Red Hat, Inc.",
     "modulePath": "model/jdk-install",
     "targetFolderName": "jdk8",
     "platform": {
       "win32": {
+        "name": "OpenJDK",
         "bundle": "yes",
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi?workflow=direct",
         "url": "http://download-node-02.eng.bos.redhat.com/brewroot/packages/openjdk8-win/1.8.0.131/1.b11/win/java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi",
@@ -91,8 +91,8 @@
         "virusTotalReport": "https://virustotal.com/en/file/8cad7ee221e5491f73abd422ff25e5ea2ac08e3844df69fdb1dce5af5db08559/analysis/1493101480/"
       },
       "darwin": {
+        "name": "Oracle Java",
         "bundle": "no",
-        "prefix": "java-1.8.0-openjdk-1.8.0",
         "dmUrl": "http://www.oracle.com/technetwork/java/javase/downloads/index.html",
         "url": "http://www.oracle.com/technetwork/java/javase/downloads/index.html",
         "filename": "",
@@ -101,6 +101,7 @@
         "virusTotalReport": ""
       },
       "linux": {
+        "name": "OpenJDK",
         "bundle": "yes",
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi?workflow=direct",
         "url": "http://download-node-02.eng.bos.redhat.com/brewroot/packages/openjdk8-win/1.8.0.131/1.b11/win/java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi",


### PR DESCRIPTION
It should now be apparent users need to install Oracle JDK on Mac because we are bound by licence issues. And the download link is fixed as well.