### PR TITLE
JBDS-4419 Skip calling java if no jvm is available

### DIFF
--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -35,6 +35,8 @@ class JdkInstall extends InstallableItem {
     this.addOption('install', versionRegex1.exec(this.version)[1], '', true);
     return Promise.resolve().then(()=>{
       return this.findMsiInstalledJava();
+    }).then(() => {
+      return this.findDarwinJava();
     }).then((output)=>{
       this.openJdkMsi = output.length>0;
       return Util.executeCommand('java -version', 2);
@@ -113,6 +115,22 @@ class JdkInstall extends InstallableItem {
     if (Platform.OS == 'win32') {
       result = Util.writeFile(msiSearchScript, data).then(()=>{
         return Util.executeFile('powershell', args);
+      });
+    }
+    return result;
+  }
+
+  findDarwinJava() {
+    let javaHome = '/usr/libexec/java_home';
+    let result = Promise.resolve();
+    if (Platform.OS === 'darwin') {
+      result = Util.executeFile(javaHome)
+      .then((output) => {
+        if (!output || output.startsWith('Unable to find any JVMs')) {
+          return Promise.reject('No JVM found');
+        } else {
+          return Promise.resolve(output);
+        }
       });
     }
     return result;


### PR DESCRIPTION
Thankfully, one can find if java is available by calling /usr/libexec/java_home first