### PR TITLE
Clone requirements when calling loadMetadata

### DIFF
--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -16,7 +16,7 @@ class InstallerDataService {
   constructor($state, requirements = require('../../requirements.json')) {
     this.tmpDir = os.tmpdir();
 
-    if (Platform.OS === 'win32') {
+    if (Platform.getOS() === 'win32') {
       this.installRoot = 'c:\\DevelopmentSuite';
     } else {
       this.installRoot = '/Applications/DevelopmentSuite';
@@ -33,7 +33,7 @@ class InstallerDataService {
     this.toSetup = new Set();
     this.downloading = false;
     this.installing = false;
-    this.requirements = loadMetadata(requirements, Platform.OS);
+    this.requirements = loadMetadata(requirements, Platform.getOS());
     // filter download-manager urls and replace host name with stage
     // host name provided in environment variable
     let stageHost = Platform.ENV['DM_STAGE_HOST'];

--- a/browser/services/metadata.js
+++ b/browser/services/metadata.js
@@ -1,8 +1,7 @@
 'use strict';
 
 function loadMetadata(requirements, platform) {
-  let reqs = {};
-  Object.assign(reqs, requirements);
+  let reqs = JSON.parse(JSON.stringify(requirements));
   for(var object in requirements) {
     if(reqs[object].platform) {
       if(reqs[object].platform[platform]) {

--- a/gulp-tasks/dist-darwin.js
+++ b/gulp-tasks/dist-darwin.js
@@ -2,7 +2,6 @@
 
 const download = require('./download.js');
 const loadMetadata = require('../browser/services/metadata');
-const reqs = loadMetadata(require('../requirements.json'), process.platform);
 const config = require('./config.js');
 const rename = require('gulp-rename');
 const runSequence = require('run-sequence');
@@ -55,7 +54,7 @@ function buildInstaller(gulp, origin, destination, extraFiles) {
   });
 }
 
-function darwinDist(gulp) {
+function darwinDist(gulp, reqs) {
 
   // prefetch all the installer dependencies so we can package them up into the .exe
   gulp.task('prefetch', ['create-prefetch-cache-dir'], function() {

--- a/gulp-tasks/dist-win32.js
+++ b/gulp-tasks/dist-win32.js
@@ -10,14 +10,13 @@ let path = require('path'),
   runSequence = require('run-sequence'),
   fs = require('fs-extra'),
   loadMetadata = require('../browser/services/metadata'),
-  reqs = loadMetadata(require('../requirements.json'), process.platform),
   exec = require('child_process').exec,
   rcedit = require('rcedit'),
   del = require('del'),
   unzip = require('gulp-unzip'),
   child_process = require('child_process');
 
-module.exports = function(gulp) {
+module.exports = function(gulp, reqs) {
 
   let zaRoot = path.resolve(config.buildFolderRoot);
   let toolsFolder = 'tools';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var gulp = require('gulp'),
   yargs = require('yargs');
 
 require('./gulp-tasks/tests')(gulp);
-require('./gulp-tasks/dist-' + process.platform)(gulp);
+require('./gulp-tasks/dist-' + process.platform)(gulp, reqs);
 
 process.on('uncaughtException', function(err) {
   if(err) {

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -59,7 +59,7 @@ describe('CDK installer', function() {
   let failure = () => {};
 
   function stubInstaller() {
-    let reqs = loadMetadata(require('../../../requirements.json'), process.platform);
+    let reqs = loadMetadata(require('../../../requirements.json'), Platform.getOS());
     let svc = new InstallerDataService({}, reqs);
     svc.cdkRoot = 'cdkLocation';
     svc.ocBinRoot = 'ocBinRoot';

--- a/test/unit/model/hyperv-test.js
+++ b/test/unit/model/hyperv-test.js
@@ -6,151 +6,151 @@ import { default as sinonChai } from 'sinon-chai';
 import InstallerDataService from 'browser/services/data';
 import Platform from 'browser/services/platform';
 import HypervInstall from 'browser/model/hyperv';
+import child_process from 'child_process';
 chai.use(sinonChai);
 
-let child_process = require('child_process');
-
 describe('Hyper-V Installer', function() {
-  let sandbox;
+  let sandbox, hvInstall, osStub;
+
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
+    osStub = sandbox.stub(Platform, 'getOS').returns('win32');
+    hvInstall = new HypervInstall(new InstallerDataService(), 'url');
   });
+
   afterEach(function() {
     sandbox.restore();
   });
+
   describe('detectExistingInstall', function() {
     describe('on windows', function() {
-      beforeEach(function() {
-        sandbox.stub(Platform, 'getOS').returns('win32');
-      });
       it('adds option \'detected\' if hypervisor detection script prints \'Enabled\' to stdout', function() {
         sandbox.stub(child_process, 'exec').yields(undefined, 'Enabled');
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.hasOption('detected')).to.be.equal(true);
         });
       });
+
       it('does not add option \'detected\' if hypervisor detection script fails', function() {
         sandbox.stub(child_process, 'exec').yields('Failure');
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.hasOption('detected')).to.be.equal(false);
         });
       });
+
       it('does not add option \'detected\' if hypervisor detection script prints \'Disabled\' to stdout', function() {
         sandbox.stub(child_process, 'exec').yields(undefined, 'Disabled');
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.hasOption('detected')).to.be.equal(false);
         });
       });
+
       it('does not add option \'detected\' if hypervisor detection script prints nothing to stdout', function() {
         sandbox.stub(child_process, 'exec').yields(undefined, 'Disabled');
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.hasOption('detected')).to.be.equal(false);
         });
       });
+
       it('does not add option \'detected\' if hypervisor detection script prints unexpected string to stdout', function() {
         sandbox.stub(child_process, 'exec').yields(undefined, 'Disabled');
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.hasOption('detected')).to.be.equal(false);
         });
       });
     });
+
     describe('on macos', function() {
-      let hvInstall;
       let hvInstallPromise;
+
       beforeEach(function() {
-        sandbox.stub(Platform, 'getOS').returns('darwin');
+        osStub.returns('darwin');
         sandbox.stub(child_process, 'exec').yields(undefined, 'Enabled');
-        hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         hvInstallPromise = hvInstall.detectExistingInstall();
       });
+
       it('does not add option \'detected\'', function() {
         return hvInstallPromise.then(function() {
           expect(hvInstall.hasOption('detected')).to.be.equal(false);
         });
       });
+
       it('is marked as detected', function() {
         return hvInstallPromise.then(function() {
           expect(hvInstall.selectedOption).to.be.equal('detected');
         });
       });
     });
+
     describe('on linux', function() {
       beforeEach(function() {
-        sandbox.stub(Platform, 'getOS').returns('linux');
+        osStub.returns('linux');
       });
+
       it('does not add option \'detected\'', function() {
         sandbox.stub(child_process, 'exec').yields(undefined, 'Enabled');
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.hasOption('detected')).to.be.equal(false);
         });
       });
     });
   });
+
   describe('isSkipped', function() {
     describe('on windows', function() {
-      beforeEach(function() {
-        sandbox.stub(Platform, 'getOS').returns('win32');
-      });
       it('should return true if hyper-v is detectd', function() {
         sandbox.stub(child_process, 'exec').yields(undefined, 'Enabled');
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.isSkipped()).to.be.equal(true);
         });
       });
+
       it('should return true if hyper-v is not detectd', function() {
         sandbox.stub(child_process, 'exec').yields(undefined, 'Disabled');
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.isSkipped()).to.be.equal(true);
         });
       });
     });
+
     describe('on macos', function() {
       beforeEach(function() {
-        sandbox.stub(Platform, 'getOS').returns('darwin');
+        osStub.returns('darwin');
       });
+
       it('should return true', function() {
-        let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
         return hvInstall.detectExistingInstall().then(function() {
           expect(hvInstall.isSkipped()).to.be.equal(true);
         });
       });
     });
   });
+
   describe('isConfigured', function() {
     it('on windows returns true if hyper-v is detected', function() {
-      sandbox.stub(Platform, 'getOS').returns('win32');
       sandbox.stub(child_process, 'exec').yields(undefined, 'Enabled');
-      let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
       return hvInstall.detectExistingInstall().then(function() {
         expect(hvInstall.isConfigured()).to.be.equal(true);
       });
     });
+
     it('on macos returns false', function() {
-      sandbox.stub(Platform, 'getOS').returns('darwin');
-      let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
+      osStub.returns('darwin');
       return hvInstall.detectExistingInstall().then(function() {
         expect(hvInstall.isConfigured()).to.be.equal(false);
       });
     });
+
     it('on linux returns false', function() {
-      sandbox.stub(Platform, 'getOS').returns('linux');
-      let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
+      osStub.returns('linux');
       return hvInstall.detectExistingInstall().then(function() {
         expect(hvInstall.isConfigured()).to.be.equal(false);
       });
     });
   });
+
   describe('installAfterRequirements', function() {
     it('should always return resolved Promise', function() {
-      let hvInstall = new HypervInstall(new InstallerDataService(), 'url');
       return hvInstall.installAfterRequirements().then(function() {
         // promise was resolved
       }).catch(()=>{

--- a/test/unit/model/installable-item-test.js
+++ b/test/unit/model/installable-item-test.js
@@ -10,6 +10,7 @@ import Downloader from 'browser/model/helpers/downloader';
 import InstallerDataService from 'browser/services/data';
 import Hash from 'browser/model/helpers/hash';
 import {ProgressState} from 'browser/pages/install/controller';
+import Platform from 'browser/services/platform';
 
 chai.use(sinonChai);
 
@@ -30,6 +31,7 @@ describe('InstallableItem', function() {
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
     fakeProgress = sandbox.stub(new ProgressState());
+    sandbox.stub(Platform, 'getOS').returns('win32');
   });
 
   afterEach(function() {

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -17,10 +17,7 @@ chai.use(sinonChai);
 
 
 describe('InstallerDataService', function() {
-  let sandbox = sinon.sandbox.create();
-  let svc;
-  let jdk;
-  let vbox;
+  let sandbox, svc, jdk, vbox, fxExtraStub;
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
@@ -39,14 +36,13 @@ describe('InstallerDataService', function() {
     sandbox.stub(Logger, 'info');
     sandbox.stub(Logger, 'error');
     sandbox.stub(fs, 'mkdirSync');
-    fxExtraStub  = sandbox.stub(fsExtra, 'copy');
+    fxExtraStub = sandbox.stub(fsExtra, 'copy');
   });
 
   afterEach(function() {
     sandbox.restore();
   });
 
-  let fxExtraStub;
   let fakeProgress = {
     installTrigger: function() {},
     setStatus: function() {}
@@ -118,6 +114,7 @@ describe('InstallerDataService', function() {
       sandbox.stub(Platform, 'getOS').returns('win32');
       sandbox.stub(Platform, 'getEnv').returns({DM_STAGE_HOST:'localhost'});
       svc = new InstallerDataService();
+      // console.log(svc.requirements.jdk);
       expect(svc.requirements.jdk.dmUrl.startsWith('https://localhost')).equals(true);
     });
   });

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -114,7 +114,6 @@ describe('InstallerDataService', function() {
       sandbox.stub(Platform, 'getOS').returns('win32');
       sandbox.stub(Platform, 'getEnv').returns({DM_STAGE_HOST:'localhost'});
       svc = new InstallerDataService();
-      // console.log(svc.requirements.jdk);
       expect(svc.requirements.jdk.dmUrl.startsWith('https://localhost')).equals(true);
     });
   });


### PR DESCRIPTION
so that it can be called repeatedly on the same set of requirements. Basically, loadMetadata would change the data stored in require('requirements.json') and since require caches the result, it would never load the original requirements again. 
Now it should not touch the original content and instead create a working copy.