### PR TITLE
Fix system test launch for bundled installer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -159,7 +159,8 @@ gulp.task('system-test', function(cb) {
   if (process.platform === 'win32') {
     tasks.push('prepare-tools');
   }
-  return runSequence(tasks, 'unpack-installer', 'protractor-run', cb);
+  tasks.push('unpack-installer', 'protractor-run');
+  return runSequence(...tasks, cb);
 });
 
 gulp.task('create-prefetch-cache-dir', function() {

--- a/main/index.js
+++ b/main/index.js
@@ -70,7 +70,7 @@ app.on('ready', function() {
 
   // Load the index.html of the app
   mainWindow.loadURL(`file://${baseLocation}/../browser/index.html`);
-  mainWindow.bundleTempFolder = process.argv.length > 1 ? process.argv[1] : undefined;
+  mainWindow.bundleTempFolder = process.argv.length > 1 ? process.argv[1].replace(/^--/, '') : undefined;
   mainWindow.once('ready-to-show', () => {
     mainWindow.show();
   });

--- a/protractor-conf.js
+++ b/protractor-conf.js
@@ -13,11 +13,18 @@ if(process.platform === 'darwin') {
 }
 
 var executable = path.join(__dirname, 'dist', platform, 'devsuite-' + platform, 'devsuite' + installerExecSuffix);
+var chromeArgs = [];
 
 if (process.env.PTOR_TEST_RUN === 'system') {
   files = ['test/system/system-test.js'];
   report = path.join(__dirname, 'system-tests');
   executable = path.join(__dirname, process.env.PTOR_BINARY);
+  chromeArgs.push(executable);
+  if (process.platform === 'win32') {
+    executable = path.join(executable, 'devsuite.exe');
+  } else {
+    executable = path.join(executable, 'MacOS', 'Red\ Hat\ Development\ Suite\ Installer');
+  }
 } else {
   //start with login and end with installation page, because of angular synchronization issues
   files = ['test/ui/login-test.js', 'test/ui/location-test.js', 'test/ui/confirm-test.js', 'test/ui/start-test.js', 'test/ui/install-test.js'];
@@ -33,7 +40,8 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
-      binary: executable
+      binary: executable,
+      args: chromeArgs
     }
   },
 

--- a/test/system/windows/runTests.ps1
+++ b/test/system/windows/runTests.ps1
@@ -5,7 +5,8 @@ param(
   [string]$vagrant,
   [string]$cygwin,
   [string]$jdk,
-  [string]$targetFolder
+  [string]$targetFolder,
+  [string]$bundle
 )
 
 $myWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
@@ -32,7 +33,7 @@ if (-Not $myWindowsPrincipal.IsInRole($adminRole)) {
 $folder = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
 Set-Location -Path $folder
 
-npm run system-test -- --binary $binary --virtualbox $virtualbox --hyperv $hyperv --vagrant $vagrant --cygwin $cygwin --jdk $jdk --targetFolder $targetFolder
+npm run system-test -- --binary $binary --virtualbox $virtualbox --hyperv $hyperv --vagrant $vagrant --cygwin $cygwin --jdk $jdk --targetFolder $targetFolder --bundle $bundle
 
 $logs = $folder + '\..\..\..\logs';
 $targetFolder = if ($targetFolder) { $targetFolder } else { "C:\DevelopmentSuite\" }


### PR DESCRIPTION
- unpacking now works properly with bundled installer (added a switch for it)
- added the bundle folder as a chrome argument to protractor (but it keeps prepending dashes, so that's why there is the replace part - but only if the string actually starts with '--')