### PR TITLE
JBDS-4423 Refactor Installer services: dependencies resolution and installation ordering

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -10,10 +10,10 @@ import fs from 'fs-extra';
 import pify from 'pify';
 
 class CDKInstall extends InstallableItem {
-  constructor(installerDataSvc, targetFolderName, minishiftUrl, fileName, minishiftSha256) {
-    super(CDKInstall.KEY, minishiftUrl, fileName, targetFolderName, installerDataSvc, true);
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum) {
+    super(CDKInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, true);
 
-    this.sha256 = minishiftSha256;
+    this.sha256 = sha256sum;
     this.addOption('install', this.version, '', true);
     this.selected = false;
   }
@@ -29,7 +29,7 @@ class CDKInstall extends InstallableItem {
   installAfterRequirements(progress, success, failure) {
     progress.setStatus('Installing');
     let minishiftExe = this.minishiftExeLocation;
-    let installer = new Installer(CDKInstall.KEY, progress, success, failure);
+    let installer = new Installer(this.keyName, progress, success, failure);
     let ocExe;
     let ocExePattern = Platform.OS === 'win32' ? '/**/oc.exe' : '/**/oc';
     let home;
@@ -99,10 +99,15 @@ class CDKInstall extends InstallableItem {
     }
 
     env[Platform.PATH] = newPath.join(path.delimiter);
-    Logger.info(CDKInstall.KEY + ' - Set PATH environment variable to \'' + env[Platform.PATH] + '\'');
+    Logger.info(this.keyName + ' - Set PATH environment variable to \'' + env[Platform.PATH] + '\'');
     return env;
   }
-
 }
+
+function fromJson({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {
+  return new CDKInstall(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum);
+}
+
+CDKInstall.convertor = {fromJson};
 
 export default CDKInstall;

--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -102,6 +102,25 @@ class CDKInstall extends InstallableItem {
     Logger.info(this.keyName + ' - Set PATH environment variable to \'' + env[Platform.PATH] + '\'');
     return env;
   }
+
+  isConfigurationValid() {
+    let cygwin = this.installerDataSvc.getInstallable('cygwin');
+    return this.isConfigured()
+      && this.virtualizationIsConfigured()
+      && (!cygwin || cygwin.isConfigured())
+      || this.isSkipped();
+  }
+
+
+  virtualizationIsConfigured() {
+    let virtualbox = this.installerDataSvc.getInstallable('virtualbox');
+    let hyperv = this.installerDataSvc.getInstallable('hyperv');
+    return (virtualbox
+      && virtualbox.isConfigured())
+      || (hyperv
+      && hyperv.isConfigured()
+      || this.selectedOption !== 'install');
+  }
 }
 
 function fromJson({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {

--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -9,7 +9,7 @@ import Platform from '../services/platform';
 import fs from 'fs-extra';
 
 class CygwinInstall extends InstallableItem {
-  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum) {
     super(CygwinInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, false);
     this.cygwinPathScript = path.join(this.installerDataSvc.tempDir(), 'set-cygwin-path.ps1');
     this.addOption('install', this.version, '', true);
@@ -17,7 +17,7 @@ class CygwinInstall extends InstallableItem {
       this.selectedOption = 'detected';
       this.addOption('detected', '', '', true);
     }
-    this.sha256 = sha256;
+    this.sha256 = sha256sum;
   }
 
   static get KEY() {
@@ -55,7 +55,7 @@ class CygwinInstall extends InstallableItem {
   installAfterRequirements(progress, success, failure) {
     progress.setStatus('Installing');
     let originalExecFile = path.join(this.installerDataSvc.cygwinDir(), 'setup-x86_64.exe');
-    let installer = new Installer(CygwinInstall.KEY, progress, success, failure);
+    let installer = new Installer(this.keyName, progress, success, failure);
     let packagesFolder = path.join(this.installerDataSvc.cygwinDir(), 'packages');
     let rootFolder = this.installerDataSvc.cygwinDir();
 
@@ -91,5 +91,11 @@ class CygwinInstall extends InstallableItem {
     });
   }
 }
+
+function fromJson({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {
+  return new CygwinInstall(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum);
+}
+
+CygwinInstall.convertor = {fromJson};
 
 export default CygwinInstall;

--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -90,6 +90,10 @@ class CygwinInstall extends InstallableItem {
       installer.fail(error);
     });
   }
+
+  isDisabled() {
+    return !this.hasOption('detected') && this.references > 0;
+  }
 }
 
 function fromJson({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {

--- a/browser/model/devstudio-autoinstall.js
+++ b/browser/model/devstudio-autoinstall.js
@@ -6,16 +6,22 @@ let esc = require('xml-escape');
 import Platform from '../services/platform';
 
 class DevstudioAutoInstallGenerator {
-  constructor(devstudioInstallDir, jdkInstallDir, version) {
-    this.autoInstall = this.generate(devstudioInstallDir, jdkInstallDir, version);
+  constructor(devstudioInstallDir, jdkInstallDir, version, additionalLocations='', additionalIus='') {
+    this.autoInstall = this.generate(devstudioInstallDir, jdkInstallDir, version, additionalLocations, additionalIus);
   }
 
   fileContent() {
     return this.autoInstall;
   }
 
-  generate(devstudioInstallDir, jdkInstallDir, devstudioVersion) {
+  generate(devstudioInstallDir, jdkInstallDir, devstudioVersion, additionalLocations, additionalIus) {
     let exeSuffix = Platform.OS === 'win32' ? 'w.exe' : '';
+    if(additionalLocations) {
+      additionalLocations = ',' + additionalLocations.trim();
+    }
+    if (additionalIus) {
+      additionalIus = ',' + additionalIus.trim();
+    }
     let temp =
       [
         '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
@@ -30,8 +36,8 @@ class DevstudioAutoInstallGenerator {
         '<installgroup>devstudio</installgroup>',
         '</com.jboss.devstudio.core.installer.JBossAsSelectPanel>',
         '<com.jboss.devstudio.core.installer.InstallAdditionalFeaturesPanel id="features">',
-        '<ius>com.jboss.devstudio.core.package,org.testng.eclipse.feature.group</ius>',
-        '<locations>devstudio</locations>',
+        '<ius>com.jboss.devstudio.core.package,org.testng.eclipse.feature.group,' + additionalIus + '</ius>',
+        '<locations>devstudio' + additionalLocations + '</locations>',
         '</com.jboss.devstudio.core.installer.InstallAdditionalFeaturesPanel>',
         '<com.jboss.devstudio.core.installer.UpdatePacksPanel id="updatepacks"/>',
         '<com.jboss.devstudio.core.installer.DiskSpaceCheckPanel id="diskspacecheck"/>',

--- a/browser/model/devstudio.js
+++ b/browser/model/devstudio.js
@@ -51,15 +51,15 @@ class DevstudioInstall extends InstallableItem {
 
       if (jdkInstall.isInstalled()) {
         return this.headlessInstall(installer, result)
-        .then((res) => { resolve(res); })
-        .catch((err) => { reject(err); });
+          .then((res) => { resolve(res); })
+          .catch((err) => { reject(err); });
       } else {
         Logger.info(this.keyName + ' - JDK has not finished installing, listener created to be called when it has.');
         this.ipcRenderer.on('installComplete', (event, arg) => {
           if (arg == JdkInstall.KEY) {
             return this.headlessInstall(installer, result)
-            .then((res) => { resolve(res); })
-            .catch((err) => { reject(err); });
+              .then((res) => { resolve(res); })
+              .catch((err) => { reject(err); });
           }
         });
       }
@@ -79,6 +79,13 @@ class DevstudioInstall extends InstallableItem {
     );
 
     return res;
+  }
+
+  isConfigurationValid() {
+    let jdk = this.installerDataSvc.getInstallable('jdk');
+    return jdk.isConfigured()
+      && this.isConfigured()
+      || this.isSkipped();
   }
 }
 

--- a/browser/model/devstudio.js
+++ b/browser/model/devstudio.js
@@ -9,14 +9,15 @@ import Logger from '../services/logger';
 import JdkInstall from './jdk-install';
 
 class DevstudioInstall extends InstallableItem {
-  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, devstudioSha256, additionalLocations, additionalIus) {
-    super(DevstudioInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, true);
+  constructor(keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus, useDownload) {
+    super(keyName, downloadUrl, fileName, targetFolderName, installerDataSvc, true);
 
-    this.sha256 = devstudioSha256;
+    this.sha256 = sha256sum;
     this.installConfigFile = path.join(this.installerDataSvc.tempDir(), 'devstudio-autoinstall.xml');
     this.addOption('install', this.version, '', true);
     this.additionalLocations = additionalLocations;
     this.additionalIus = additionalIus;
+    this.useDownload = useDownload;
   }
 
   static get KEY() {
@@ -25,12 +26,12 @@ class DevstudioInstall extends InstallableItem {
 
   installAfterRequirements(progress, success, failure) {
     progress.setStatus('Installing');
-    this.installGenerator = new DevstudioAutoInstallGenerator(this.installerDataSvc.devstudioDir(), this.installerDataSvc.jdkDir(), this.version);
-    let installer = new Installer(DevstudioInstall.KEY, progress, success, failure);
+    this.installGenerator = new DevstudioAutoInstallGenerator(this.installerDataSvc.devstudioDir(), this.installerDataSvc.jdkDir(), this.version, this.additionalLocations, this.additionalIus);
+    let installer = new Installer(this.keyName, progress, success, failure);
 
-    Logger.info(DevstudioInstall.KEY + ' - Generate devstudio auto install file content');
+    Logger.info(this.keyName + ' - Generate devstudio auto install file content');
     let data = this.installGenerator.fileContent();
-    Logger.info(DevstudioInstall.KEY + ' - Generate devstudio auto install file content SUCCESS');
+    Logger.info(this.keyName + ' - Generate devstudio auto install file content SUCCESS');
 
     return installer.writeFile(this.installConfigFile, data)
       .then((result) => {
@@ -53,7 +54,7 @@ class DevstudioInstall extends InstallableItem {
         .then((res) => { resolve(res); })
         .catch((err) => { reject(err); });
       } else {
-        Logger.info(DevstudioInstall.KEY + ' - JDK has not finished installing, listener created to be called when it has.');
+        Logger.info(this.keyName + ' - JDK has not finished installing, listener created to be called when it has.');
         this.ipcRenderer.on('installComplete', (event, arg) => {
           if (arg == JdkInstall.KEY) {
             return this.headlessInstall(installer, result)
@@ -66,7 +67,7 @@ class DevstudioInstall extends InstallableItem {
   }
 
   headlessInstall(installer) {
-    Logger.info(DevstudioInstall.KEY + ' - headlessInstall() called');
+    Logger.info(this.keyName + ' - headlessInstall() called');
     let javaOpts = [
       '-DTRACE=true',
       '-jar',
@@ -80,5 +81,11 @@ class DevstudioInstall extends InstallableItem {
     return res;
   }
 }
+
+function fromJson({keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus, useDownload}) {
+  return new DevstudioInstall(keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus, useDownload);
+}
+
+DevstudioInstall.convertor = {fromJson};
 
 export default DevstudioInstall;

--- a/browser/model/hyperv.js
+++ b/browser/model/hyperv.js
@@ -53,7 +53,12 @@ class HypervInstall extends InstallableItem {
       return true;
     }
   }
-
 }
+
+function fromJson({installerDataSvc, downloadUrl}) {
+  return new HypervInstall(installerDataSvc, downloadUrl);
+}
+
+HypervInstall.convertor = {fromJson};
 
 export default HypervInstall;

--- a/browser/model/hyperv.js
+++ b/browser/model/hyperv.js
@@ -6,6 +6,7 @@ import Platform from '../services/platform';
 class HypervInstall extends InstallableItem {
   constructor(installerDataSvc, downloadUrl) {
     super(HypervInstall.KEY, downloadUrl, '', '', installerDataSvc, false);
+    this.selectedOption = 'detected';
   }
 
   static get KEY() {
@@ -52,6 +53,10 @@ class HypervInstall extends InstallableItem {
     } else {
       return true;
     }
+  }
+
+  isDisabled() {
+    return true;
   }
 }
 

--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -51,6 +51,7 @@ class InstallableItem {
     this.installAfter = undefined;
     this.ipcRenderer = ipcRenderer;
     this.authRequired = authRequired;
+    this.references = 0;
   }
 
   getProductName() {
@@ -220,6 +221,9 @@ class InstallableItem {
     return this.selectedOption == 'detected';
   }
 
+  isSelected() {
+    return this.selectedOption == 'install';
+  }
 
   getLocation() {
     return this.isDetected()
@@ -250,6 +254,13 @@ class InstallableItem {
     success();
   }
 
+  isDisabled() {
+    return this.references > 0;
+  }
+
+  isConfigurationValid() {
+    return true;
+  }
 }
 
 export default InstallableItem;

--- a/browser/model/jbosseap.js
+++ b/browser/model/jbosseap.js
@@ -104,6 +104,14 @@ class JbosseapInstall extends InstallableItem {
 
     return res;
   }
+
+  isConfigurationValid() {
+    let jdk = this.installerDataSvc.getInstallable('jdk');
+    return jdk.isConfigured()
+      && this.isConfigured()
+      || this.isSkipped();
+  }
+  
 }
 
 function fromJson({ installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {

--- a/browser/model/jbosseap.js
+++ b/browser/model/jbosseap.js
@@ -11,9 +11,9 @@ import Logger from '../services/logger';
 import JdkInstall from './jdk-install';
 
 class JbosseapInstall extends InstallableItem {
-  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, jbosseapSha256) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum) {
     super(JbosseapInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, true);
-    this.sha256 = jbosseapSha256;
+    this.sha256 = sha256sum;
     this.installConfigFile = path.join(this.installerDataSvc.tempDir(), 'jbosseap-autoinstall.xml');
     this.configFile = path.join(this.installerDataSvc.tempDir(), 'jbosseap-autoinstall.xml.variables');
     this.addOption('install', this.version, '', true);
@@ -27,13 +27,13 @@ class JbosseapInstall extends InstallableItem {
     progress.setStatus('Installing');
     let version = /(\d+\.\d+\.\d+).*/.exec(this.version)[1];
     this.installGenerator = new JbosseapAutoInstallGenerator(this.installerDataSvc.jbosseapDir(), this.installerDataSvc.jdkDir(), version);
-    let installer = new Installer(JbosseapInstall.KEY, progress, success, failure);
+    let installer = new Installer(this.keyName, progress, success, failure);
 
     if(fs.existsSync(this.installerDataSvc.jbosseapDir())) {
       rimraf.sync(this.installerDataSvc.jbosseapDir());
     }
 
-    Logger.info(JbosseapInstall.KEY + ' - Generate jbosseap auto install file content');
+    Logger.info(this.keyName + ' - Generate jbosseap auto install file content');
     let data = this.installGenerator.fileContent();
     Logger.info(JbosseapInstall.KEY + ' - Generate jbosseap auto install file content SUCCESS');
     return Promise.resolve().then(()=> {
@@ -63,8 +63,8 @@ class JbosseapInstall extends InstallableItem {
     let escapedLocation = this.installerDataSvc.jbosseapDir().replace(/\\/g, '\\\\').replace(/\:/g, '\\:');
     if(fs.existsSync(runtimeproperties)) {
       fs.appendFile(runtimeproperties, `\njbosseap=${escapedLocation},true`).catch((error)=>{
-        Logger.error(JbosseapInstall.KEY + ' - error occured during runtime detection configuration in DevStudio');
-        Logger.error(JbosseapInstall.KEY + ` -  ${error}`);
+        Logger.error(this.keyName + ' - error occured during runtime detection configuration in DevStudio');
+        Logger.error(this.keyName + ` -  ${error}`);
       });
     }
   }
@@ -75,15 +75,15 @@ class JbosseapInstall extends InstallableItem {
 
       if (jdkInstall.isInstalled()) {
         return this.headlessInstall(installer, result)
-        .then((res) => { resolve(res); })
-        .catch((err) => { reject(err); });
+          .then((res) => { resolve(res); })
+          .catch((err) => { reject(err); });
       } else {
-        Logger.info(JbosseapInstall.KEY + ' - JDK has not finished installing, listener created to be called when it has.');
+        Logger.info(this.keyName + ' - JDK has not finished installing, listener created to be called when it has.');
         this.ipcRenderer.on('installComplete', (event, arg) => {
           if (arg == JdkInstall.KEY) {
             return this.headlessInstall(installer, result)
-            .then((res) => { resolve(res); })
-            .catch((err) => { reject(err); });
+              .then((res) => { resolve(res); })
+              .catch((err) => { reject(err); });
           }
         });
       }
@@ -91,7 +91,7 @@ class JbosseapInstall extends InstallableItem {
   }
 
   headlessInstall(installer) {
-    Logger.info(JbosseapInstall.KEY + ' - headlessInstall() called');
+    Logger.info(this.keyName + ' - headlessInstall() called');
     let javaOpts = [
       '-DTRACE=true',
       '-jar',
@@ -105,5 +105,11 @@ class JbosseapInstall extends InstallableItem {
     return res;
   }
 }
+
+function fromJson({ installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {
+  return new JbosseapInstall(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum);
+}
+
+JbosseapInstall.convertor = {fromJson};
 
 export default JbosseapInstall;

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -13,12 +13,16 @@ import Util from './helpers/util';
 import Version from './helpers/version';
 
 class JdkInstall extends InstallableItem {
-  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, jdkSha256) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum) {
     super(JdkInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, true);
-    this.sha256 = jdkSha256;
+    this.sha256 = sha256sum;
     this.existingVersion = '';
     this.minimumVersion = '1.8.0';
     this.openJdkMsi = false;
+  }
+
+  static get KEY() {
+    return 'jdk';
   }
 
   getLocation() {
@@ -75,8 +79,8 @@ class JdkInstall extends InstallableItem {
         return Promise.reject('Cannot detect Java home folder');
       }
     }).catch((error) => {
-      Logger.info(JdkInstall.KEY + ' - Detection failed with error');
-      Logger.info(JdkInstall.KEY + ' - ' + error);
+      Logger.info(this.keyName + ' - Detection failed with error');
+      Logger.info(this.keyName + ' - ' + error);
       if(this.option.detected) {
         delete this.option.detected;
       }
@@ -150,13 +154,9 @@ class JdkInstall extends InstallableItem {
     }
   }
 
-  static get KEY() {
-    return 'jdk';
-  }
-
   installAfterRequirements(progress, success, failure) {
     progress.setStatus('Installing');
-    let installer = new Installer(JdkInstall.KEY, progress, success, failure);
+    let installer = new Installer(this.keyName, progress, success, failure);
 
     if(fs.existsSync(this.installerDataSvc.jdkDir())) {
       rimraf.sync(this.installerDataSvc.jdkDir());
@@ -169,7 +169,7 @@ class JdkInstall extends InstallableItem {
         let regexTargetDir = /.*Dir \(target\): Key: INSTALLDIR\s\, Object\:\s(.*)/;
         let targetDir = regexTargetDir.exec(line)[1];
         if(targetDir !== this.getLocation()) {
-          Logger.info(JdkInstall.KEY + ' - OpenJDK location not detected, it is installed into ' + targetDir + ' according info in log file');
+          Logger.info(this.keyName + ' - OpenJDK location not detected, it is installed into ' + targetDir + ' according info in log file');
           this.installerDataSvc.jdkRoot = targetDir;
         }
         installer.succeed(true);
@@ -203,5 +203,11 @@ class JdkInstall extends InstallableItem {
     return super.isConfigured();
   }
 }
+
+function fromJson({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {
+  return new JdkInstall(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum);
+}
+
+JdkInstall.convertor = {fromJson};
 
 export default JdkInstall;

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -202,6 +202,13 @@ class JdkInstall extends InstallableItem {
     }
     return super.isConfigured();
   }
+
+  isDisabled() {
+    return !this.hasOption('detected') && (this.references > 0)
+    || this.hasOption('detected') && !this.option.detected.valid && (this.references > 0)
+    || this.hasOption('detected') && this.option.detected.valid && this.openJdkMsi
+    || Platform.OS === 'darwin';
+  }
 }
 
 function fromJson({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {

--- a/browser/model/kompose.js
+++ b/browser/model/kompose.js
@@ -7,10 +7,10 @@ import Installer from './helpers/installer';
 import Platform from '../services/platform';
 
 class KomposeInstall extends InstallableItem {
-  constructor(installerDataSvc, targetFolderName, version, downloadUrl, fileName, sha256) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum) {
     super(KomposeInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, false);
     this.addOption('install', this.version, '', true);
-    this.sha256 = sha256;
+    this.sha256 = sha256sum;
   }
 
   static get KEY() {
@@ -34,6 +34,13 @@ class KomposeInstall extends InstallableItem {
       installer.fail(error);
     });
   }
+
 }
+
+function fromJson({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum}) {
+  return new KomposeInstall(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum);
+}
+
+KomposeInstall.convertor = {fromJson};
 
 export default KomposeInstall;

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -50,6 +50,10 @@ class VirtualBoxInstall extends InstallableItem {
       }
     }
   }
+
+  isDisabled() {
+    return this.hasOption('detected') || this.references > 0;
+  }
 }
 
 class VirtualBoxInstallWindows extends VirtualBoxInstall {

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -11,7 +11,7 @@ import Version from './helpers/version';
 import del from 'del';
 
 class VirtualBoxInstall extends InstallableItem {
-  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256, version, revision) {
+  constructor(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, version, revision) {
     super(VirtualBoxInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, false);
 
     this.minimumVersion = version;
@@ -21,7 +21,7 @@ class VirtualBoxInstall extends InstallableItem {
     this.downloadUrl = this.downloadUrl.split('${version}').join(this.version);
     this.downloadUrl = this.downloadUrl.split('${revision}').join(this.revision);
 
-    this.sha256 = sha256;
+    this.sha256 = sha256sum;
     this.addOption('install', this.version, '', true);
   }
 
@@ -109,7 +109,7 @@ class VirtualBoxInstallWindows extends VirtualBoxInstall {
   }
 
   installAfterRequirements(progress, success, failure) {
-    let installer = new Installer(VirtualBoxInstall.KEY, progress, success, failure);
+    let installer = new Installer(this.keyName, progress, success, failure);
     return installer.execFile(
       this.downloadedFile, ['--extract', '-path', this.installerDataSvc.virtualBoxDir(), '--silent']
     ).then(() => {
@@ -126,7 +126,7 @@ class VirtualBoxInstallWindows extends VirtualBoxInstall {
     return new Promise((resolve, reject) => {
       // If downloading is not finished wait for event
       if (this.installerDataSvc.downloading) {
-        Logger.info(VirtualBoxInstall.KEY + ' - Waiting for all downloads to complete');
+        Logger.info(this.keyName + ' - Waiting for all downloads to complete');
         installer.progress.setStatus('Waiting for all downloads to finish');
         this.ipcRenderer.on('downloadingComplete', () => {
           // time to start virtualbox installer
@@ -157,7 +157,7 @@ class VirtualBoxInstallWindows extends VirtualBoxInstall {
         let regexTargetDir = /CopyDir: DestDir=(.*)\,.*/;
         let targetDir = regexTargetDir.exec(result)[1];
         if(targetDir !== this.getLocation()) {
-          Logger.info(VirtualBoxInstall.KEY + ' - virtual box location not detected, but it is installed into ' + targetDir + ' according info in log file');
+          Logger.info(this.keyName + ' - virtual box location not detected, but it is installed into ' + targetDir + ' according info in log file');
           this.setOptionLocation('install', targetDir);
         }
         resolve(res);
@@ -172,6 +172,14 @@ class VirtualBoxInstallWindows extends VirtualBoxInstall {
     });
   }
 }
+
+function fromJsonWindows({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, version, revision}) {
+  return new VirtualBoxInstallWindows(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, version, revision);
+}
+
+VirtualBoxInstallWindows.convertor = {fromJson: fromJsonWindows};
+
+
 
 class VirtualBoxInstallDarwin extends VirtualBoxInstall {
 
@@ -217,7 +225,7 @@ class VirtualBoxInstallDarwin extends VirtualBoxInstall {
 
   installAfterRequirements(progress, success, failure) {
     progress.setStatus('Installing');
-    let installer = new Installer(VirtualBoxInstall.KEY, progress, success, failure);
+    let installer = new Installer(this.keyName, progress, success, failure);
     return installer.exec(this.getScript()).then((result) => {
       installer.succeed(result);
     }).catch((error) => {
@@ -240,9 +248,16 @@ class VirtualBoxInstallDarwin extends VirtualBoxInstall {
     ].join(' ');
     return osaScript;
   }
+
+  static convertor() {
+  }
 }
 
+function fromJsonDarwin({installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, version, revision}) {
+  return new VirtualBoxInstallDarwin(installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, version, revision);
+}
 
+VirtualBoxInstallDarwin.convertor = {fromJson: fromJsonDarwin};
 
 export default Platform.identify({
   darwin: ()=>VirtualBoxInstallDarwin,

--- a/browser/pages/confirm/confirm.html
+++ b/browser/pages/confirm/confirm.html
@@ -17,7 +17,7 @@
            ng-class="{'dotted-panel':checkboxModel.devstudio.hasOption('detected')}">
            <!--ng-click="checkboxModel.devstudio.changeIsCollapsed()">-->
            <div class="checkbox-container verticalLine"> <!--ng-show="!checkboxModel.devstudio.hasOption('detected')"-->
-             <input id="devstudio-checkbox" type="checkbox" ng-model="checkboxModel.devstudio.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
+             <input id="devstudio-checkbox" type="checkbox" ng-disabled="checkboxModel.devstudio.isDisabled()" ng-model="checkboxModel.devstudio.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
            </div>
         <div class="checkbox-container" ng-show="false">
           <div id="arrow-devstudio" class="arrow" ng-class="{'arrow-down':!checkboxModel.devstudio.isCollapsed}" aria-label="Toggle ngHide"></div>
@@ -101,7 +101,7 @@
            ng-class="{'dotted-panel':checkboxModel.jdk.hasOption('detected')&&checkboxModel.jdk.selectedOption === 'detected' || platform === 'darwin'}">
            <!--ng-click="checkboxModel.jdk.changeIsCollapsed()">-->
            <div class="checkbox-container verticalLine">
-             <input id="jdk-checkbox" type="checkbox" ng-disabled="!checkboxModel.jdk.hasOption('detected') && (checkboxModel.jbosseap.selectedOption === 'install' || checkboxModel.devstudio.selectedOption === 'install') || checkboxModel.jdk.hasOption('detected') && !checkboxModel.jdk.option.detected.valid && (checkboxModel.jbosseap.selectedOption === 'install' || checkboxModel.devstudio.selectedOption === 'install') || checkboxModel.jdk.hasOption('detected') && checkboxModel.jdk.option.detected.valid && checkboxModel.jdk.openJdkMsi || platform==='darwin'" ng-model="checkboxModel.jdk.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
+             <input id="jdk-checkbox" type="checkbox" ng-disabled="checkboxModel.jdk.isDisabled()" ng-model="checkboxModel.jdk.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
            </div>
         <div class="checkbox-container" ng-show="false">
           <div id="arrow-jdk" class="arrow" ng-class="{'arrow-down':!checkboxModel.jdk.isCollapsed}" aria-label="Toggle ngHide"></div>
@@ -322,7 +322,7 @@
            ng-class="{'dotted-panel':checkboxModel.virtualbox.hasOption('detected')}">
            <!--ng-click="checkboxModel.virtualbox.changeIsCollapsed()">-->
            <div class="checkbox-container verticalLine">
-             <input id="virtualbox-checkbox" type="checkbox" ng-disabled="checkboxModel.virtualbox.hasOption('detected') || checkboxModel.cdk.selectedOption=='install'" ng-model="checkboxModel.virtualbox.selectedOption" ng-true-value="'install'" ng-false-value="'detected'" aria-label="Toggle ngHide" class="vallign-middle"  title="{{checkboxModel.virtualbox.hasOption('detected')?'Update is not supported yet':'Select to install';}}">
+             <input id="virtualbox-checkbox" type="checkbox" ng-disabled="checkboxModel.virtualbox.isDisabled()" ng-model="checkboxModel.virtualbox.selectedOption" ng-true-value="'install'" ng-false-value="'detected'" aria-label="Toggle ngHide" class="vallign-middle"  title="{{checkboxModel.virtualbox.hasOption('detected')?'Update is not supported yet':'Select to install';}}">
            </div>
         <div class="checkbox-container" ng-show="false">
           <div id="arrow-virtualbox" class="arrow" ng-class="{'arrow-down':!checkboxModel.virtualbox.isCollapsed}" aria-label="Toggle ngHide"></div>
@@ -444,7 +444,7 @@
            ng-class="{'dotted-panel':checkboxModel.cygwin.hasOption('detected') && checkboxModel.cygwin.selectedOption === 'detected'}">
            <!--ng-click="checkboxModel.cygwin.changeIsCollapsed()">-->
            <div class="checkbox-container verticalLine">
-             <input id="cygwin-checkbox" type="checkbox" ng-disabled="!checkboxModel.cygwin.hasOption('detected') && checkboxModel.cdk.selectedOption == 'install'" ng-model="checkboxModel.cygwin.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
+             <input id="cygwin-checkbox" type="checkbox" ng-disabled="checkboxModel.cygwin.isDisabled()" ng-model="checkboxModel.cygwin.selectedOption" aria-label="Toggle ngHide" class="vallign-middle" ng-true-value="'install'" ng-false-value="'detected'">
            </div>
         <div class="checkbox-container" ng-show="false">
           <div id="arrow-cygwin" class="arrow" ng-class="{'arrow-down':!checkboxModel.cygwin.isCollapsed}" aria-label="Toggle ngHide"></div>

--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -19,7 +19,6 @@ class ConfirmController {
     this.installerDataSvc = installerDataSvc;
     this.electron = electron;
     this.loader = new ComponentLoader(installerDataSvc);
-
     this.installedSearchNote = '';
     this.isDisabled = false;
     this.numberOfExistingInstallations = 0;
@@ -39,56 +38,65 @@ class ConfirmController {
 
     $scope.isConfigurationValid = this.isConfigurationValid;
 
-    let watchedComponents = {};
-    for (let key in baseDependencies) {
-      if ($scope.checkboxModel[key]) {
-        watchedComponents[key] = [];
-        let installAfter = this.installerDataSvc.getInstallable(key).getInstallAfter();
-        let keyName;
-
-        while (installAfter) {
-          keyName = installAfter.keyName;
-          if (baseDependencies[key].indexOf(keyName) > -1) {
-            watchedComponents[key].push(keyName);
-          }
-          installAfter = installAfter.getInstallAfter();
-        }
-      }
-    }
-
-    for (let key in watchedComponents) {
-      $scope.$watch(`checkboxModel.${key}.selectedOption`, function watchComponent(nVal) {
-        for (let keyName of watchedComponents[key]) {
-          if (keyName === 'jdk' && $scope.checkboxModel[keyName].selectedOption !== 'detected') {
-            if ($scope.checkboxModel.devstudio.selectedOption === 'detected' && $scope.checkboxModel.jbosseap.selectedOption === 'detected' ) {
-              $scope.checkboxModel[keyName].selectedOption = 'detected';
-            } else {
-              $scope.checkboxModel[keyName].selectedOption = 'install';
-            }
-          } else {
-            if(nVal=='install') {
-              if($scope.checkboxModel[keyName].selectedOption == 'detected'
-                && !$scope.checkboxModel[keyName].hasOption('detected')) {
-                $scope.checkboxModel[keyName].selectedOption = 'install';
-              }
-            } else if (nVal=='detected') {
-              $scope.checkboxModel[keyName].selectedOption = 'detected';
-            }
-          }
-        }
-      });
-    }
-
     $scope.$watch('$viewContentLoaded', ()=>{
-      this.detectInstalledComponents();
+      this.initPage();
     });
 
     this.electron.remote.getCurrentWindow().addListener('focus', ()=> {
       this.timeout( () => {
-        this.detectInstalledComponents();
+        this.activatePage();
         this.sc.$apply();
       });
     });
+  }
+
+  initPage() {
+    return this.detectInstalledComponents().then(()=> {
+      this.graph = ComponentLoader.loadGraph(this.installerDataSvc);
+      this.installWatchers();
+      return Promise.resolve();
+    }).then(
+      ()=> this.setIsDisabled()
+    ).catch((error)=> {
+      Logger.error(error);
+      this.setIsDisabled();
+    });
+  }
+
+  activatePage() {
+    return this.detectInstalledComponents().then(
+      ()=> this.setIsDisabled()
+    ).catch((error)=> {
+      Logger.error(error);
+      this.setIsDisabled();
+    });
+  }
+
+  installWatchers() {
+    let nodes = this.graph.overallOrder() ;
+    for (let node of nodes) {
+      this.sc.checkboxModel[node].references=0;
+    }
+    for (let node of nodes) {
+      let watchComponent = ()=> {
+        if(!this.sc.checkboxModel[node].isSelected()) {
+          for(let dep of this.graph.dependenciesOf(node)) {
+            this.sc.checkboxModel[dep].references--;
+            if(!this.sc.checkboxModel[dep].isDisabled()) {
+              this.sc.checkboxModel[dep].selectedOption = 'detected';
+            }
+          }
+        } else {
+          for(let dep of this.graph.dependenciesOf(node)) {
+            if(!this.sc.checkboxModel[dep].isDisabled()) {
+              this.sc.checkboxModel[dep].selectedOption = 'install';
+            }
+            this.sc.checkboxModel[dep].references++;
+          }
+        }
+      };
+      this.sc.$watch(`checkboxModel.${node}.selectedOption`, watchComponent);
+    }
   }
 
   detectInstalledComponents() {
@@ -99,11 +107,7 @@ class ConfirmController {
       for (var installer of this.installerDataSvc.allInstallables().values()) {
         detectors.push(installer.detectExistingInstall());
       }
-      this.detection = Promise.all(detectors).then(()=> {
-        this.setIsDisabled();
-      }).catch(()=> {
-        this.setIsDisabled();
-      });
+      this.detection = Promise.all(detectors);
     }
     return this.detection;
   }
@@ -166,39 +170,14 @@ class ConfirmController {
     });
   }
 
-  devstudioIsConfigured() {
-    return this.sc.checkboxModel.jdk.isConfigured()
-      && this.sc.checkboxModel.devstudio.isConfigured()
-      || this.sc.checkboxModel.devstudio.isSkipped();
-  }
-
-  eapIsConfigured() {
-    return this.sc.checkboxModel.jdk.isConfigured()
-      && this.sc.checkboxModel.jbosseap.isConfigured()
-      || this.sc.checkboxModel.jbosseap.isSkipped();
-  }
-
-  cdkIsConfigured() {
-    return this.sc.checkboxModel.cdk.isConfigured()
-      && this.virtualizationIsConfigured()
-      && (!this.sc.checkboxModel.cygwin || this.sc.checkboxModel.cygwin.isConfigured())
-      || this.sc.checkboxModel.cdk.isSkipped();
-  }
-
-  virtualizationIsConfigured() {
-    return (this.sc.checkboxModel.virtualbox
-      && this.sc.checkboxModel.virtualbox.isConfigured())
-      || (this.sc.checkboxModel.hyperv
-      && this.sc.checkboxModel.hyperv.isConfigured()
-      || this.sc.checkboxModel.cdk.selectedOption !== 'install');
-  }
-
   isConfigurationValid() {
-    return this.devstudioIsConfigured()
-      && this.eapIsConfigured()
-      && this.cdkIsConfigured()
-      && this.virtualizationIsConfigured()
-      && this.isAtLeastOneSelected();
+    let result = true;
+    for (let [, value] of this.installerDataSvc.allInstallables().entries()) {
+      if(! (result = value.isConfigurationValid())) {
+        break;
+      }
+    }
+    return result && this.isAtLeastOneSelected();
   }
 
   isAtLeastOneSelected() {

--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -88,10 +88,10 @@ class ConfirmController {
           }
         } else {
           for(let dep of this.graph.dependenciesOf(node)) {
-            if(!this.sc.checkboxModel[dep].isDisabled()) {
+            this.sc.checkboxModel[dep].references++;
+            if(this.sc.checkboxModel[dep].isDisabled()) {
               this.sc.checkboxModel[dep].selectedOption = 'install';
             }
-            this.sc.checkboxModel[dep].references++;
           }
         }
       };

--- a/browser/services/componentLoader.js
+++ b/browser/services/componentLoader.js
@@ -44,7 +44,6 @@ class ComponentLoader {
     let newOrder = {};
     Object.assign(newOrder, this.buildBaseOrder());
     let changed;
-
     do {
       changed = false;
       for (let item of Object.keys(newOrder)) {
@@ -76,7 +75,7 @@ class ComponentLoader {
     let baseOrder = {
       root: []
     };
-    let requirements = JSON.parse(JSON.stringify(require('../../requirements.json')));
+    let requirements = this.installerDataSvc.requirements;
     for (let key in requirements) {
       let item = requirements[key];
       if( item.bundle !== 'tools') {

--- a/browser/services/componentLoader.js
+++ b/browser/services/componentLoader.js
@@ -1,19 +1,5 @@
 'use strict';
 
-import InstallerDataService from './data';
-
-const baseOrder = {
-  'root': ['jdk'],
-  'jdk':  ['virtualbox', 'devstudio', 'jbosseap'],
-  'virtualbox': ['hyperv'],
-  'hyperv': ['cygwin'],
-  'cygwin': ['cdk'],
-  'devstudio': [],
-  'jbosseap': [],
-  'cdk': [],
-  'kompose': []
-};
-
 class ComponentLoader {
   constructor(installerDataSvc) {
     this.requirements = installerDataSvc.requirements;
@@ -41,26 +27,21 @@ class ComponentLoader {
 
   addComponent(key) {
     if (this.requirements[key] && this.requirements[key].bundle !== 'tools') {
-      let skippedProperties = ['name', 'description', 'bundle', 'vendor', 'virusTotalReport', 'modulePath'];
-      let args = [this.installerDataSvc];
-      if (this.requirements[key].dmUrl) {
-        skippedProperties.push('url');
+      this.requirements[key].keyName = key;
+      this.requirements[key].installerDataSvc = this.installerDataSvc;
+      if(this.requirements[key].dmUrl) {
+        this.requirements[key].downloadUrl = this.requirements[key].dmUrl;
+      } else {
+        this.requirements[key].downloadUrl = this.requirements[key].url;
       }
-
-      for (let property in this.requirements[key]) {
-        if (skippedProperties.indexOf(property) < 0) {
-          args.push(this.requirements[key][property]);
-        }
-      }
-      let component = new DynamicClass(this.requirements[key].modulePath, args);
-
+      let component = new DynamicClass(this.requirements[key].modulePath, this.requirements[key]);
       this.installerDataSvc.addItemToInstall(key, component);
     }
   }
 
   orderInstallation() {
     let newOrder = {};
-    Object.assign(newOrder, baseOrder);
+    Object.assign(newOrder, this.buildBaseOrder());
     let changed;
 
     do {
@@ -80,21 +61,46 @@ class ComponentLoader {
           }
         }
       }
-    } while (changed)
+    } while (changed);
 
     for (let [key, value] of this.installerDataSvc.allInstallables()) {
-      for (var i = 0; i < newOrder[key].length; i++) {
+      for (let i = 0; i < newOrder[key].length; i++) {
         let nextItem = this.installerDataSvc.getInstallable(newOrder[key][i]);
         value.thenInstall(nextItem);
       }
     }
   }
+
+  buildBaseOrder() {
+    let baseOrder = {
+      root: []
+    };
+    let requirements = JSON.parse(JSON.stringify(require('../../requirements.json')));
+    for (let key in requirements) {
+      let item = requirements[key];
+      if( item.bundle !== 'tools') {
+        if(baseOrder[key] == undefined) {
+          baseOrder[key] = [];
+        }
+        if(item.installAfter == undefined) {
+          baseOrder.root.push(key);
+        } else {
+          if (baseOrder[item.installAfter] == undefined) {
+            baseOrder[item.installAfter] = [];
+          }
+          baseOrder[item.installAfter].push(key);
+        }
+      }
+    }
+    return baseOrder;
+  }
 }
 
 class DynamicClass {
-  constructor (modulePath, opts) {
+  constructor (modulePath, config) {
     let klass = require(`../${modulePath}`);
-    return new klass.default(...opts);
+    let obj = klass.default.convertor.fromJson(config);
+    return obj;
   }
 }
 

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -233,12 +233,12 @@ class InstallerDataService {
 
     let item = this.getInstallable(key);
     return item.setup(progress,
-        () => {
-          this.setupDone(progress, key);
-        },
-        (error) => {
-          Logger.error(key + ' failed to install: ' + error);
-        }
+      () => {
+        this.setupDone(progress, key);
+      },
+      (error) => {
+        Logger.error(key + ' failed to install: ' + error);
+      }
     );
   }
 

--- a/gulp-tasks/dist-win32.js
+++ b/gulp-tasks/dist-win32.js
@@ -55,7 +55,7 @@ module.exports = function(gulp, reqs) {
     if (fs.existsSync(path.resolve(config.prefetchFolder)) && installerExe.indexOf('-bundle') > 0) {
       packCmd = zaExe + ' a -m0=Copy ' + bundled7z + ' ' + installerExe.replace('-bundle', '') + ' ' + path.resolve(config.prefetchFolder) + path.sep + '*';
     } else {
-      packCmd = zaExe + ' a ' + bundled7z + ' ' + zaElectronPackage + path.sep + '* ' + path.resolve(config.prefetchFolder) + path.sep + reqs['cygwin'].filename;
+      packCmd = zaExe + ' a ' + bundled7z + ' ' + zaElectronPackage + path.sep + '* ' + path.resolve(config.prefetchFolder) + path.sep + reqs['cygwin'].fileName;
     }
     //console.log('[DEBUG]' + packCmd);
     exec(packCmd, common.createExecCallback(cb, true));
@@ -99,7 +99,7 @@ module.exports = function(gulp, reqs) {
   // prefetch cygwin to always include into installer
   gulp.task('prefetch-cygwin-packages', ['create-prefetch-cache-dir'], function() {
     return new Promise(function(resolve, reject) {
-      child_process.exec(`${path.resolve(config.prefetchFolder)}\\${reqs.cygwin.filename} -D --no-admin --quiet-mode --only-site -l ${path.resolve(config.prefetchFolder, 'packages')} --site http://mirrors.xmission.com/cygwin --categories Base --packages openssh,rsync --root ${path.resolve(config.prefetchFolder, 'packages')}`, function(error, std, err) {
+      child_process.exec(`${path.resolve(config.prefetchFolder)}\\${reqs.cygwin.fileName} -D --no-admin --quiet-mode --only-site -l ${path.resolve(config.prefetchFolder, 'packages')} --site http://mirrors.xmission.com/cygwin --categories Base --packages openssh,rsync --root ${path.resolve(config.prefetchFolder, 'packages')}`, function(error, std, err) {
         if(error) {
           reject(error);
         } else {

--- a/gulp-tasks/download.js
+++ b/gulp-tasks/download.js
@@ -86,11 +86,11 @@ function prefetch(reqs, bundle, targetFolder) {
   let promises = new Array();
   for (let key in reqs) {
     if (reqs[key].bundle === bundle) {
-      let currentFile = path.join(targetFolder, reqs[key].filename);
+      let currentFile = path.join(targetFolder, reqs[key].fileName);
       promises.push(() => {
         return new Promise((resolve, reject) => {
           // if file is already downloaded, check its sha against the stored one
-          downloadAndReadSHA256(targetFolder, reqs[key].filename + '.sha256', reqs[key].sha256sum, reject, (currentSHA256) => {
+          downloadAndReadSHA256(targetFolder, reqs[key].fileName + '.sha256', reqs[key].sha256sum, reject, (currentSHA256) => {
             //console.log('[DEBUG] SHA256SUM for ' + key + ' = ' + currentSHA256);
             comm.isExistingSHA256Current(currentFile, currentSHA256, (dl) => {
               if(dl) {
@@ -102,7 +102,7 @@ function prefetch(reqs, bundle, targetFolder) {
                 } else {
                   console.log('[INFO] \'' + currentFile + '\' is not downloaded yet');
                 }
-                downloadFileAndCreateSha256(targetFolder, reqs[key].filename, reqs[key].url, currentSHA256, resolve, reject);
+                downloadFileAndCreateSha256(targetFolder, reqs[key].fileName, reqs[key].url, currentSHA256, resolve, reject);
               }
             });
           });

--- a/gulp-tasks/https-server.js
+++ b/gulp-tasks/https-server.js
@@ -41,8 +41,8 @@ function handleRequest(req, res) {
         console.log(requirement.dmUrl);
         if(requirement.dmUrl && requirement.dmUrl.endsWith(url)
           || requirement.url && requirement.url.endsWith(url) ) {
-          console.log('Issuing redirect ' + 'https://' + req.headers['host'] + '/' + requirement.filename);
-          res.writeHead(302, { 'Location': 'https://' + req.headers['host'] + '/requirements-cache/' + requirement.filename });
+          console.log('Issuing redirect ' + 'https://' + req.headers['host'] + '/' + requirement.fileName);
+          res.writeHead(302, { 'Location': 'https://' + req.headers['host'] + '/requirements-cache/' + requirement.fileName });
           res.end();
           return;
         }

--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
     "update-deps": "node_modules/.bin/ncu --upgrade --loglevel verbose --packageFile package.json && npm update"
   },
   "dependencies": {
+    "@uirouter/angularjs": "1.0.5",
     "angular": "1.6.4",
     "angular-base64": "2.0.5",
     "angular-messages": "1.6.4",
     "angular-mocks": "1.6.4",
-    "@uirouter/angularjs": "1.0.5",
     "del": "3.0.0",
+    "dependency-graph": "^0.5.0",
     "fs-extra": "3.0.1",
     "glob": "7.1.2",
     "globby": "6.1.0",

--- a/requirements.json
+++ b/requirements.json
@@ -49,7 +49,7 @@
     "targetFolderName": "cygwin",
     "installAfter": "virtualbox",
     "url": "https://cygwin.com/setup-x86_64.exe",
-    "filename": "cygwin_2.8.1-1.exe",
+    "fileName": "cygwin_2.8.1-1.exe",
     "sha256sum": "062ab45437fed70071dd4cf1c9d6c584f3efbb3d64d60e4cfc4e74fd6b6de214",
     "version": "2.8.1-1",
     "virusTotalReport": "https://virustotal.com/en/file/062ab45437fed70071dd4cf1c9d6c584f3efbb3d64d60e4cfc4e74fd6b6de214/analysis/",

--- a/requirements.json
+++ b/requirements.json
@@ -7,7 +7,6 @@
     "installable": true,
     "detectable": false,
     "targetFolderName": "cdk",
-    "installAfter": "cygwin",
     "platform": {
       "win32": {
         "bundle": "yes",
@@ -16,7 +15,8 @@
         "fileName": "minishift_3_0_0_GA.exe",
         "sha256sum": "4f51b5b6bc8fc93bda5d25f5f58f213a8165b6c0e0f2b77dbb53ae6da4966068",
         "version": "3.0.0.GA",
-        "requires": ["cygwin","hyperv||virtualbox"]
+        "requires": ["cygwin","hyperv||virtualbox"],
+        "installAfter": "cygwin"
       },
       "darwin": {
         "bundle": "yes",
@@ -25,7 +25,8 @@
         "fileName": "minishift_3_0_0_GA",
         "sha256sum": "1aad3cc784f312568357c9d3e1a2111ceedac884c59e0953b06aea45de49bb25",
         "version": "3.0.0.GA",
-        "requires": ["virtualbox"]
+        "requires": ["virtualbox"],
+        "installAfter": "virtualbox"
       },
       "linux": {
         "bundle": "yes",
@@ -34,7 +35,8 @@
         "fileName": "minishift_3_0_0_GA",
         "sha256sum": "b754554190756fb3142998b67cd046174f7e0ae9f2d287d673481e20d9482060",
         "version": "3.0.0.GA",
-        "requires": ["kvm"]
+        "requires": ["kvm"],
+        "installAfter": "virtualbox"
       }
     }
   },

--- a/requirements.json
+++ b/requirements.json
@@ -69,9 +69,9 @@
     "installAfter": "jdk",
     "dmUrl": "https://devstudio.redhat.com/11/snapshots/builds/devstudio.product_master/latest/all/",
     "url": "https://devstudio.redhat.com/11/snapshots/builds/devstudio.product_master/latest/all/",
-    "fileName": "devstudio-11.0.0.AM1-installer-standalone.jar",
+    "fileName": "devstudio-11.0.0.AM2-installer-standalone.jar",
     "sha256sum": "",
-    "version": "11.0.0.AM1",
+    "version": "11.0.0.AM2",
     "useDownload": true,
     "requires": "jdk"
   },

--- a/requirements.json
+++ b/requirements.json
@@ -16,7 +16,7 @@
         "fileName": "minishift_3_0_0_GA.exe",
         "sha256sum": "4f51b5b6bc8fc93bda5d25f5f58f213a8165b6c0e0f2b77dbb53ae6da4966068",
         "version": "3.0.0.GA",
-        "requires": "cygwin,hyperv||virtualbox"
+        "requires": ["cygwin","hyperv||virtualbox"]
       },
       "darwin": {
         "bundle": "yes",
@@ -25,7 +25,7 @@
         "fileName": "minishift_3_0_0_GA",
         "sha256sum": "1aad3cc784f312568357c9d3e1a2111ceedac884c59e0953b06aea45de49bb25",
         "version": "3.0.0.GA",
-        "requires": "virtualbox"
+        "requires": ["virtualbox"]
       },
       "linux": {
         "bundle": "yes",
@@ -34,7 +34,7 @@
         "fileName": "minishift_3_0_0_GA",
         "sha256sum": "b754554190756fb3142998b67cd046174f7e0ae9f2d287d673481e20d9482060",
         "version": "3.0.0.GA",
-        "requires": "kvm"
+        "requires": ["kvm"]
       }
     }
   },
@@ -73,7 +73,7 @@
     "sha256sum": "",
     "version": "11.0.0.AM2",
     "useDownload": true,
-    "requires": "jdk"
+    "requires": ["jdk"]
   },
   "jbosseap": {
     "name": "Red Hat JBoss Enterprise Application Platform",
@@ -90,7 +90,7 @@
     "fileName": "jboss-eap-7.0.0-installer.jar",
     "sha256sum": "8c4432464414ab986d0aa4c6b0faee94b797cf1f66949dd98496ca0ae54d7d35",
     "version": "7.0.0.GA",
-    "requires": "jdk"
+    "requires": ["jdk"]
   },
   "jdk": {
     "description": "A free and open source implementation of the Java Platform, Standard Edition (Java SE)",

--- a/requirements.json
+++ b/requirements.json
@@ -4,31 +4,37 @@
     "description": "Developer Tools for Creating, Testing, and Distributing Red Hat Container-Based Applications",
     "vendor": "Red Hat, Inc.",
     "modulePath": "model/cdk",
+    "installable": true,
+    "detectable": false,
     "targetFolderName": "cdk",
+    "installAfter": "cygwin",
     "platform": {
       "win32": {
         "bundle": "yes",
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/cdk-3.0-minishift-windows-amd64.exe?workflow=direct",
         "url": "http://cdk-builds.usersys.redhat.com/builds/weekly/09-May-2017.cdk-3.0.0/windows-amd64/minishift.exe",
-        "filename": "minishift_3_0_0_GA.exe",
+        "fileName": "minishift_3_0_0_GA.exe",
         "sha256sum": "4f51b5b6bc8fc93bda5d25f5f58f213a8165b6c0e0f2b77dbb53ae6da4966068",
-        "version": "3.0.0.GA"
+        "version": "3.0.0.GA",
+        "requires": "cygwin,hyperv||virtualbox"
       },
       "darwin": {
         "bundle": "yes",
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/cdk-3.0-minishift-darwin-amd64?workflow=direct",
         "url": "http://cdk-builds.usersys.redhat.com/builds/weekly/09-May-2017.cdk-3.0.0/darwin-amd64/minishift",
-        "filename": "minishift_3_0_0_GA",
+        "fileName": "minishift_3_0_0_GA",
         "sha256sum": "1aad3cc784f312568357c9d3e1a2111ceedac884c59e0953b06aea45de49bb25",
-        "version": "3.0.0.GA"
+        "version": "3.0.0.GA",
+        "requires": "virtualbox"
       },
       "linux": {
         "bundle": "yes",
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/cdk-3.0-minishift-linux-amd64?workflow=direct",
         "url": "http://cdk-builds.usersys.redhat.com/builds/weekly/09-May-2017.cdk-3.0.0/linux-amd64/minishift",
-        "filename": "minishift_3_0_0_GA",
+        "fileName": "minishift_3_0_0_GA",
         "sha256sum": "b754554190756fb3142998b67cd046174f7e0ae9f2d287d673481e20d9482060",
-        "version": "3.0.0.GA"
+        "version": "3.0.0.GA",
+        "requires": "kvm"
       }
     }
   },
@@ -37,8 +43,11 @@
     "description": "A distribution of popular GNU and other Open Source tools running on Microsoft Windows",
     "vendor": "Community Project",
     "modulePath": "model/cygwin",
+    "installable": true,
+    "detectable": true,
     "bundle": "always",
     "targetFolderName": "cygwin",
+    "installAfter": "virtualbox",
     "url": "https://cygwin.com/setup-x86_64.exe",
     "filename": "cygwin_2.8.1-1.exe",
     "sha256sum": "062ab45437fed70071dd4cf1c9d6c584f3efbb3d64d60e4cfc4e74fd6b6de214",
@@ -53,63 +62,72 @@
     "description": "A certified Eclipse-based integrated development environment (IDE)",
     "vendor": "Red Hat, Inc.",
     "modulePath": "model/devstudio",
+    "installable": true,
+    "detectable": false,
     "bundle": "yes",
     "targetFolderName": "developer-studio",
+    "installAfter": "jdk",
     "dmUrl": "https://devstudio.redhat.com/11/snapshots/builds/devstudio.product_master/latest/all/",
     "url": "https://devstudio.redhat.com/11/snapshots/builds/devstudio.product_master/latest/all/",
-    "filename": "devstudio-11.0.0.AM2-installer-standalone.jar",
+    "fileName": "devstudio-11.0.0.AM1-installer-standalone.jar",
     "sha256sum": "",
-    "version": "11.0.0.AM2"
+    "version": "11.0.0.AM1",
+    "useDownload": true,
+    "requires": "jdk"
   },
   "jbosseap": {
     "name": "Red Hat JBoss Enterprise Application Platform",
     "description": "Java EE 7 compliant application server built on open standards",
     "vendor": "Red Hat, Inc.",
     "modulePath": "model/jbosseap",
+    "installable": true,
+    "detectable": false,
     "bundle": "no",
     "targetFolderName": "jbosseap",
+    "installAfter": "jdk",
     "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/jboss-eap-7.0.0-installer.jar?workflow=direct",
     "url": "http://download-node-02.eng.bos.redhat.com/released/JBEAP-7/7.0.0/jboss-eap-7.0.0-installer.jar",
-    "filename": "jboss-eap-7.0.0-installer.jar",
+    "fileName": "jboss-eap-7.0.0-installer.jar",
     "sha256sum": "8c4432464414ab986d0aa4c6b0faee94b797cf1f66949dd98496ca0ae54d7d35",
-    "version": "7.0.0.GA"
+    "version": "7.0.0.GA",
+    "requires": "jdk"
   },
   "jdk": {
+    "description": "A free and open source implementation of the Java Platform, Standard Edition (Java SE)",
+    "vendor": "Red Hat, Inc.",
     "modulePath": "model/jdk-install",
     "targetFolderName": "jdk8",
+    "detectable": true,
     "platform": {
       "win32": {
-        "description": "A free and open source implementation of the Java Platform, Standard Edition (Java SE)",
-        "vendor": "Red Hat, Inc.",
         "name": "OpenJDK",
+        "installable": true,
         "bundle": "yes",
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi?workflow=direct",
         "url": "http://download-node-02.eng.bos.redhat.com/brewroot/packages/openjdk8-win/1.8.0.131/1.b11/win/java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi",
-        "filename": "java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi",
+        "fileName": "java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi",
         "sha256sum": "8cad7ee221e5491f73abd422ff25e5ea2ac08e3844df69fdb1dce5af5db08559",
         "version": "1.8.0_131",
         "virusTotalReport": "https://virustotal.com/en/file/8cad7ee221e5491f73abd422ff25e5ea2ac08e3844df69fdb1dce5af5db08559/analysis/1493101480/"
       },
       "darwin": {
-        "description": "Java Platform, Standard Edition (Java SE)",
-        "vendor": "Oracle, Inc.",
         "name": "Oracle Java",
+        "installable": false,
         "bundle": "no",
         "dmUrl": "http://www.oracle.com/technetwork/java/javase/downloads/index.html",
         "url": "http://www.oracle.com/technetwork/java/javase/downloads/index.html",
-        "filename": "",
+        "fileName": "",
         "sha256sum": "",
         "version": "1.8.0",
         "virusTotalReport": ""
       },
       "linux": {
-        "description": "A free and open source implementation of the Java Platform, Standard Edition (Java SE)",
-        "vendor": "Red Hat, Inc.",
         "name": "OpenJDK",
         "bundle": "yes",
+        "installable": true,
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi?workflow=direct",
         "url": "http://download-node-02.eng.bos.redhat.com/brewroot/packages/openjdk8-win/1.8.0.131/1.b11/win/java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi",
-        "filename": "java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi",
+        "fileName": "java-1.8.0-openjdk-1.8.0.131-1.b11.redhat.windows.x86_64.msi",
         "sha256sum": "8cad7ee221e5491f73abd422ff25e5ea2ac08e3844df69fdb1dce5af5db08559",
         "version": "1.8.0_131",
         "virusTotalReport": "https://virustotal.com/en/file/8cad7ee221e5491f73abd422ff25e5ea2ac08e3844df69fdb1dce5af5db08559/analysis/1493101480/"
@@ -121,12 +139,15 @@
     "description": "A virtualization software package developed by Oracle",
     "vendor": "Oracle, Inc.",
     "modulePath": "model/virtualbox",
+    "installable": true,
+    "detectable": true,
     "targetFolderName": "virtualbox",
+    "installAfter": "jdk",
     "platform": {
       "win32": {
         "bundle": "no",
         "url": "https://developers.redhat.com/redirect/to/virtualbox-windows-5.1.22.download",
-        "filename": "virtualbox_5.1.22.exe",
+        "fileName": "virtualbox_5.1.22.exe",
         "sha256sum": "e36883bb27653aabe20ca0cbf140b2aa19573fc989c47e3cce7986dc544b0e93",
         "version": "5.1.22",
         "revision": "115126",
@@ -135,7 +156,7 @@
       "darwin": {
         "bundle": "no",
         "url": "https://developers.redhat.com/redirect/to/virtualbox-macos-5.1.22.download",
-        "filename": "virtualbox_5.1.22.dmg",
+        "fileName": "virtualbox_5.1.22.dmg",
         "sha256sum": "405cbb3795f95fb74a216293d1160b2adfb264a43476e1366e3c897e0efa36aa",
         "version": "5.1.22",
         "revision": "115126",
@@ -144,7 +165,7 @@
       "linux": {
         "bundle": "no",
         "url": "http://download.virtualbox.org/virtualbox/5.1.22/VirtualBox-5.1-5.1.22_115126_fedora25-1.x86_64.rpm",
-        "filename": "VirtualBox-5.1-5.1.22_115126_fedora25-1.x86_64.rpm",
+        "fileName": "VirtualBox-5.1-5.1.22_115126_fedora25-1.x86_64.rpm",
         "sha256sum": "c112cddf30c3b6f20958f6212fc114c13c8c5ce82caed3d3892d1e6a7bd66a88",
         "version": "5.1.22",
         "revision": "115126",
@@ -156,9 +177,11 @@
     "name": "Microsoft Hyper-V",
     "description": "Microsoft Windows Virtualization Platform",
     "modulePath": "model/hyperv",
+    "installable": false,
+    "detectable": true,
     "bundle": "no",
     "url": "https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/",
-    "filename": "",
+    "fileName": "",
     "sha256sum": "",
     "version": "",
     "revision": "112440",
@@ -177,7 +200,7 @@
         "bundle": "tools",
         "version": "9.20",
         "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/9.20/7za920.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsevenzip%2Ffiles%2F7-Zip%2F9.20%2F",
-        "filename": "7zip.zip",
+        "fileName": "7zip.zip",
         "sha256sum": "2a3afe19c180f8373fa02ff00254d5394fec0349f5804e0ad2f6067854ff28ac"
       }
     }
@@ -191,7 +214,7 @@
         "bundle": "tools",
         "version": "9.20",
         "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/9.20/7z920_extra.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsevenzip%2Ffiles%2F7-Zip%2F9.20%2F",
-        "filename": "7zip-extra.7z",
+        "fileName": "7zip-extra.7z",
         "sha256sum": "d65a1d1a050e4fd7912c18468954f64db824a1e1b621235a153d010beae14757"
       }
     }
@@ -201,22 +224,24 @@
     "description": "A tool to translate a Docker Compose file into Kubernetes or OpenShift resources",
     "vendor": "Kubernetes Incubator",
     "modulePath": "model/kompose",
+    "installable": true,
+    "detectable": false,
     "targetFolderName": "kompose",
     "version": "0.6.0 Technology Preview",
     "platform": {
       "win32": {
         "url": "https://developers.redhat.com/redirect/to/kompose-windows-0.6.0.download",
-        "filename": "kompose-0.6.0.TP-windows-amd64.exe",
+        "fileName": "kompose-0.6.0.TP-windows-amd64.exe",
         "sha256sum": "2b641b12c3e8c1aae1b63b0d32dedc4e4128fd906c752893050a0f7a549f83fa"
       },
       "darwin": {
         "url": "https://developers.redhat.com/redirect/to/kompose-macos-0.6.0.download",
-        "filename": "kompose-0.6.0.TP-darwin-amd64",
+        "fileName": "kompose-0.6.0.TP-darwin-amd64",
         "sha256sum": "fe2253f3535226e27e22d137a04c6383175f38822c1389d7ee043ad243320200"
       },
       "linux": {
         "url": "https://github.com/kubernetes-incubator/kompose/releases/download/v0.6.0/kompose-linux-amd64",
-        "filename": "kompose-0.6.0.TP-linux-amd64",
+        "fileName": "kompose-0.6.0.TP-linux-amd64",
         "sha256sum": "1597d3ef7b663d38b3758eceeec36951c0d99449b7949b61f0355157003b9094"
       }
     }

--- a/test/ui/start-test.js
+++ b/test/ui/start-test.js
@@ -8,11 +8,11 @@ describe('Getting Started Page', function() {
 
   beforeAll(function() {
     browser.setLocation('start')
-    .then(function() {
-      devstudioButton = element(By.id('start-submit'));
-      closeButton = element(By.id('exit-btn'));
-      quickstartLink = element(By.id('quickstart-link'));
-    });
+      .then(function() {
+        devstudioButton = element(By.id('start-submit'));
+        closeButton = element(By.id('exit-btn'));
+        quickstartLink = element(By.id('quickstart-link'));
+      });
   });
 
   it('should display a button to start devstudio', function() {

--- a/test/unit/model/kompose-test.js
+++ b/test/unit/model/kompose-test.js
@@ -62,7 +62,7 @@ describe('kompose installer', function() {
   let failure = () => {};
 
   beforeEach(function () {
-    installer = new KomposeInstall(installerDataSvc, 'folderName', '0.4.0', komposeUrl, 'kompose.exe', 'sha1');
+    installer = new KomposeInstall(installerDataSvc, 'folderName', komposeUrl, 'kompose.exe', 'sha1');
     sandbox = sinon.sandbox.create();
     fakeProgress = sandbox.stub(new ProgressState());
   });
@@ -73,13 +73,13 @@ describe('kompose installer', function() {
 
   it('should fail when some download url is not set and installed file not defined', function() {
     expect(function() {
-      new KomposeInstall(installerDataSvc, 'folderName', '0.4.0', null, 'installFile', 'sha1');
+      new KomposeInstall(installerDataSvc, 'folderName', null, 'installFile', 'sha1');
     }).to.throw('No download URL set');
   });
 
   it('should fail when no url is set and installed file is empty', function() {
     expect(function() {
-      new KomposeInstall(installerDataSvc, 'folderName', '0.4.0', null, 'installFile', 'sha1');
+      new KomposeInstall(installerDataSvc, 'folderName', null, 'installFile', 'sha1');
     }).to.throw('No download URL set');
   });
 

--- a/test/unit/pages/confirm/controller-test.js
+++ b/test/unit/pages/confirm/controller-test.js
@@ -146,7 +146,6 @@ describe('ConfirmController', function() {
             el[1]('install');
           }
         });
-        console.log($watch.args);
         expect(confirmController.sc.checkboxModel.jdk.selectedOption).equals('install');
       });
     });
@@ -159,7 +158,6 @@ describe('ConfirmController', function() {
         $watch.args.forEach(function(el) {
           if(el[1].name == 'watchComponent'
             && el[0] == 'checkboxModel.cdk.selectedOption') {
-            console.log(1);
             el[1]('detected');
           }
         });

--- a/test/unit/pages/confirm/controller-test.js
+++ b/test/unit/pages/confirm/controller-test.js
@@ -128,18 +128,27 @@ describe('ConfirmController', function() {
     it('should select openjdk if jbosseap or devstudio selected', function() {
       return confirmController.initPage().then(function() {
         expect(confirmController.sc.checkboxModel.jdk.selectedOption).equals('install');
+        expect(confirmController.sc.checkboxModel.devstudio.selectedOption).equals('install');
+        expect(confirmController.sc.checkboxModel.jbosseap.selectedOption).equals('install');
+        $watch.args.forEach(function(el) {
+          if(el[1].name == 'watchComponent'
+            && ( el[0] == 'checkboxModel.jbosseap.selectedOption'
+              || el[0] == 'checkboxModel.devstudio.selectedOption')) {
+            el[1]();
+          }
+        });
         confirmController.sc.checkboxModel.devstudio.selectedOption = 'detected';
         confirmController.sc.checkboxModel.jbosseap.selectedOption = 'detected';
         $watch.args.forEach(function(el) {
           if(el[1].name == 'watchComponent'
-            && el[0] == 'checkboxModel.jbosseap.selectedOption'
-            || el[0] == 'checkboxModel.devstudio.selectedOption') {
+            && ( el[0] == 'checkboxModel.jbosseap.selectedOption'
+              || el[0] == 'checkboxModel.devstudio.selectedOption')) {
             el[1]('detected');
           }
         });
         expect(confirmController.sc.checkboxModel.jdk.selectedOption).equals('detected');
+
         confirmController.sc.checkboxModel.devstudio.selectedOption = 'install';
-        confirmController.detectInstalledComponents();
         $watch.args.forEach(function(el) {
           if(el[1].name == 'watchComponent'
             && el[0] == 'checkboxModel.devstudio.selectedOption') {
@@ -170,20 +179,26 @@ describe('ConfirmController', function() {
       return confirmController.initPage().then(function() {
         expect(confirmController.sc.checkboxModel.cygwin.selectedOption).equals('install');
         expect(confirmController.sc.checkboxModel.virtualbox.selectedOption).equals('install');
+        expect(confirmController.sc.checkboxModel.cdk.selectedOption).equals('install');
+        $watch.args.forEach(function(el) {
+          if(el[1].name == 'watchComponent'
+            && 'checkboxModel.cdk.selectedOption') {
+            el[1]();
+          }
+        });
         confirmController.sc.checkboxModel.cdk.selectedOption = 'detected';
         $watch.args.forEach(function(el) {
           if(el[1].name == 'watchComponent'
             && el[0] == 'checkboxModel.cdk.selectedOption') {
-            el[1]('detected');
+            el[1]();
           }
         });
-        expect(confirmController.sc.checkboxModel.cygwin.selectedOption).equals('detected');
-        expect(confirmController.sc.checkboxModel.virtualbox.selectedOption).equals('detected');
+
         confirmController.sc.checkboxModel.cdk.selectedOption = 'install';
         $watch.args.forEach(function(el) {
           if(el[1].name == 'watchComponent'
             && el[0] == 'checkboxModel.cdk.selectedOption') {
-            el[1]('install');
+            el[1]();
           }
         });
         expect(confirmController.sc.checkboxModel.cygwin.selectedOption).equals('install');

--- a/test/unit/services/componentLoader-test.js
+++ b/test/unit/services/componentLoader-test.js
@@ -156,19 +156,6 @@ describe('Component Loader', function() {
       expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
       expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
     });
-
-    it('should squash the install sequence if some component not present', function() {
-      svc = new InstallerDataService({}, reducedReqs2);
-      loader = new ComponentLoader(svc);
-      addAll(loader, reducedReqs2);
-      loader.orderInstallation();
-
-      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
-      expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('cygwin')).to.equal(undefined);
-      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('virtualbox');
-    });
   });
 
   describe('removeComponent', function() {

--- a/test/unit/services/componentLoader-test.js
+++ b/test/unit/services/componentLoader-test.js
@@ -15,9 +15,10 @@ describe('Component Loader', function() {
       bundle: 'yes',
       dmUrl: 'cdkDmUrl',
       url: 'cdkUrl',
-      filename: 'minishift.exe',
+      fileName: 'minishift.exe',
       sha256sum: 'cdkSHA',
-      version: '3.0.0.GA'
+      version: '3.0.0.GA',
+      installAfter: 'cygwin'
     },
     'jdk': {
       name: 'jdk',
@@ -26,7 +27,7 @@ describe('Component Loader', function() {
       bundle: 'yes',
       dmUrl: 'jdkDmUrl',
       url: 'jdkUrl',
-      filename: 'jdk.msi',
+      fileName: 'jdk.msi',
       sha256sum: 'jdkSHA',
       version: '1.8.0'
     },
@@ -37,9 +38,10 @@ describe('Component Loader', function() {
       bundle: 'yes',
       url: 'devstudioUrl',
       dmUrl: 'devstudioDmUrl',
-      filename: 'devstudio.jar',
+      fileName: 'devstudio.jar',
       sha256sum: 'devstudioSHA',
-      version: '10.4.0'
+      version: '10.4.0',
+      installAfter: 'jdk'
     },
     'cygwin': {
       name: 'cygwin',
@@ -47,9 +49,10 @@ describe('Component Loader', function() {
       targetFolderName: 'cygwinFolder',
       bundle: 'always',
       url: 'cygwinUrl',
-      filename: 'cygwin.exe',
+      fileName: 'cygwin.exe',
       sha256sum: 'cygwinSHA',
-      version: '2.7.0'
+      version: '2.7.0',
+      installAfter: 'virtualbox'
     },
     'virtualbox': {
       name: 'virtualbox',
@@ -57,15 +60,16 @@ describe('Component Loader', function() {
       targetFolderName: 'virtualboxFolder',
       bundle: 'no',
       url: 'virtualboxUrl',
-      filename: 'virtualbox.exe',
+      fileName: 'virtualbox.exe',
       sha256sum: 'virtualboxSHA',
-      version: '5.1.12'
+      version: '5.1.12',
+      installAfter: 'jdk'
     },
     '7zip': {
       name: '7zip',
       bundle: 'tools',
       url: '7zipUrl',
-      filename: '7zip.exe',
+      fileName: '7zip.exe',
       sha256sum: '7zipSHA',
       version: '1.0.0'
     }

--- a/test/unit/services/componentLoader-test.js
+++ b/test/unit/services/componentLoader-test.js
@@ -18,7 +18,21 @@ describe('Component Loader', function() {
       fileName: 'minishift.exe',
       sha256sum: 'cdkSHA',
       version: '3.0.0.GA',
-      installAfter: 'cygwin'
+      installAfter: 'cygwin',
+      requires: ['cygwin', 'virtualbox']
+    },
+    'devstudio': {
+      name: 'devstudio',
+      modulePath: 'model/devstudio',
+      targetFolderName: 'devstudioFolder',
+      bundle: 'yes',
+      url: 'devstudioUrl',
+      dmUrl: 'devstudioDmUrl',
+      fileName: 'devstudio.jar',
+      sha256sum: 'devstudioSHA',
+      version: '10.4.0',
+      installAfter: 'jdk',
+      requires : ['jdk']
     },
     'jdk': {
       name: 'jdk',
@@ -31,7 +45,7 @@ describe('Component Loader', function() {
       sha256sum: 'jdkSHA',
       version: '1.8.0'
     },
-    'devstudio': {
+    'fusetools': {
       name: 'devstudio',
       modulePath: 'model/devstudio',
       targetFolderName: 'devstudioFolder',
@@ -41,7 +55,8 @@ describe('Component Loader', function() {
       fileName: 'devstudio.jar',
       sha256sum: 'devstudioSHA',
       version: '10.4.0',
-      installAfter: 'jdk'
+      installAfter: 'devstudio',
+      requires : ['devstudio']
     },
     'cygwin': {
       name: 'cygwin',


### PR DESCRIPTION
This fix includes prep changes required for Fuse Tools Installer:
* moves installer ordering configuration from code to
requirements.json file;
* introduce additional parameter for devstudio installer to allow fuse
installer to provide correct key value;
* introduces additional parameters to list additional IUs to install;
* swithces to factory metod fromJason to create installer instances;
* add 'requires' attributes to installer's configuration, but those are
not used yet on confirmation page.