### PR TITLE
JBDS-4464 Fuse Platform does not get added to runtime detection

### DIFF
--- a/browser/model/jbossfuse.js
+++ b/browser/model/jbossfuse.js
@@ -80,7 +80,7 @@ class FusePlatformInstall extends InstallableItem {
         devstudio.configureRuntimeDetection('fuse-platform-on-eap', this.installerDataSvc.fuseplatformDir());
       } else {
         this.ipcRenderer.on('installComplete', (event, arg)=> {
-          if(arg == 'devstudio') {
+          if(arg == 'fusetools') {
             devstudio.configureRuntimeDetection('fuse-platform-on-eap', this.installerDataSvc.fuseplatformDir());
           }
         });

--- a/browser/model/jbossfusekaraf.js
+++ b/browser/model/jbossfusekaraf.js
@@ -48,7 +48,7 @@ class FusePlatformInstallKaraf extends InstallableItem {
         devstudio.configureRuntimeDetection('fuse-platform-on-karaf', this.installerDataSvc.fuseplatformkarafDir());
       } else {
         this.ipcRenderer.on('installComplete', (event, arg)=> {
-          if(arg == 'devstudio') {
+          if(arg == 'fusetools') {
             devstudio.configureRuntimeDetection('fuse-platform-on-karaf', this.installerDataSvc.fuseplatformkarafDir());
           }
         });

--- a/test/unit/model/fuseplatformkaraf-test.js
+++ b/test/unit/model/fuseplatformkaraf-test.js
@@ -108,11 +108,11 @@ describe('jbossplaformkaraf nstaller', function() {
       let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
       mockDevSuiteInstaller.emitEntries();
       return promise.then(()=>{
-        let devstudioInstaller = fuseInstaller.installerDataSvc.getInstallable('devstudio');
+        let devstudioInstaller = fuseInstaller.installerDataSvc.getInstallable('fusetools');
         expect(devstudioInstaller.configureRuntimeDetection).not.called;
         fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'jdk');
         expect(devstudioInstaller.configureRuntimeDetection).not.called;
-        fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'devstudio');
+        fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'fusetools');
         expect(devstudioInstaller.configureRuntimeDetection).calledOnce;
       });
     });


### PR DESCRIPTION
Fix attaches runtime detection configuration to installation
of fuse tools.