### PR TITLE
JBDS-4469 Some servers added to runtime detection only with fuse tools

### DIFF
--- a/browser/model/devstudio.js
+++ b/browser/model/devstudio.js
@@ -39,7 +39,7 @@ class DevstudioInstall extends InstallableItem {
 
     return installer.writeFile(this.installConfigFile, data)
       .then((result) => {
-        return this.postJDKInstall(installer, result);
+        return this.headlessInstall(installer, result);
       })
       .then(() => {
         installer.succeed(true);
@@ -47,27 +47,6 @@ class DevstudioInstall extends InstallableItem {
       .catch((error) => {
         installer.fail(error);
       });
-  }
-
-  postJDKInstall(installer, result) {
-    return new Promise((resolve, reject) => {
-      let jdkInstall = this.installerDataSvc.getInstallable(JdkInstall.KEY);
-
-      if (jdkInstall.isInstalled()) {
-        return this.headlessInstall(installer, result)
-          .then((res) => { resolve(res); })
-          .catch((err) => { reject(err); });
-      } else {
-        Logger.info(this.keyName + ' - JDK has not finished installing, listener created to be called when it has.');
-        this.ipcRenderer.on('installComplete', (event, arg) => {
-          if (arg == JdkInstall.KEY) {
-            return this.headlessInstall(installer, result)
-              .then((res) => { resolve(res); })
-              .catch((err) => { reject(err); });
-          }
-        });
-      }
-    });
   }
 
   headlessInstall(installer) {

--- a/browser/model/devstudio.js
+++ b/browser/model/devstudio.js
@@ -30,9 +30,6 @@ class DevstudioInstall extends InstallableItem {
     progress.setStatus('Installing');
     this.installGenerator = new DevstudioAutoInstallGenerator(this.installerDataSvc.devstudioDir(), this.installerDataSvc.jdkDir(), this.version, this.additionalLocations, this.additionalIus);
     let installer = new Installer(this.keyName, progress, success, failure);
-    if(fs.existsSync(this.bundledFile)) {
-      this.downloadedFile = this.bundledFile;
-    }
     Logger.info(this.keyName + ' - Generate devstudio auto install file content');
     let data = this.installGenerator.fileContent();
     Logger.info(this.keyName + ' - Generate devstudio auto install file content SUCCESS');

--- a/browser/model/jbosseap.js
+++ b/browser/model/jbosseap.js
@@ -39,7 +39,7 @@ class JbosseapInstall extends InstallableItem {
     return Promise.resolve().then(()=> {
       return installer.writeFile(this.installConfigFile, data);
     }).then((result) => {
-      return this.postJDKInstall(installer, result);
+      return this.headlessInstall(installer, result);
     }).then(() => {
       let devstudio = this.installerDataSvc.getInstallable('devstudio');
       if(devstudio.installed) {
@@ -54,27 +54,6 @@ class JbosseapInstall extends InstallableItem {
       installer.succeed(true);
     }).catch((error) => {
       installer.fail(error);
-    });
-  }
-
-  postJDKInstall(installer, result) {
-    return new Promise((resolve, reject) => {
-      let jdkInstall = this.installerDataSvc.getInstallable(JdkInstall.KEY);
-
-      if (jdkInstall.isInstalled()) {
-        return this.headlessInstall(installer, result)
-          .then((res) => { resolve(res); })
-          .catch((err) => { reject(err); });
-      } else {
-        Logger.info(this.keyName + ' - JDK has not finished installing, listener created to be called when it has.');
-        this.ipcRenderer.on('installComplete', (event, arg) => {
-          if (arg == JdkInstall.KEY) {
-            return this.headlessInstall(installer, result)
-              .then((res) => { resolve(res); })
-              .catch((err) => { reject(err); });
-          }
-        });
-      }
     });
   }
 

--- a/browser/model/jbosseap.js
+++ b/browser/model/jbosseap.js
@@ -41,16 +41,14 @@ class JbosseapInstall extends InstallableItem {
     }).then((result) => {
       return this.headlessInstall(installer, result);
     }).then(() => {
-      let devstudio = this.installerDataSvc.getInstallable('devstudio');
-      if(devstudio.installed) {
-        devstudio.configureRuntimeDetection('jbosseap', this.installerDataSvc.jbosseapDir());
-      } else {
-        this.ipcRenderer.on('installComplete', (event, arg)=> {
-          if(arg == 'devstudio') {
+      this.ipcRenderer.on('installComplete', (event, arg)=> {
+        if(arg == 'all') {
+          let devstudio = this.installerDataSvc.getInstallable('devstudio');
+          if(devstudio.installed) {
             devstudio.configureRuntimeDetection('jbosseap', this.installerDataSvc.jbosseapDir());
           }
-        });
-      }
+        }
+      });
       installer.succeed(true);
     }).catch((error) => {
       installer.fail(error);

--- a/browser/model/jbossfuse.js
+++ b/browser/model/jbossfuse.js
@@ -73,14 +73,14 @@ class FusePlatformInstall extends InstallableItem {
     return Promise.resolve().then(()=> {
       return installer.writeFile(this.installConfigFile, installGenerator(this.installerDataSvc.fuseplatformDir()));
     }).then(()=> {
-        return this.headlessEapInstall(installer);
+      return this.headlessEapInstall(installer);
     }).then(()=> {
-        return this.headlessInstall(installer);
+      return this.headlessInstall(installer);
     }).then(()=> {
       this.ipcRenderer.on('installComplete', (event, arg)=> {
         if(arg == 'all') {
           let devstudio = this.installerDataSvc.getInstallable('devstudio');
-          if(devstudio.installed()) {
+          if(devstudio.installed) {
             devstudio.configureRuntimeDetection('fuse-platform-on-eap', this.installerDataSvc.fuseplatformDir());
           }
         }

--- a/browser/model/jbossfuse.js
+++ b/browser/model/jbossfuse.js
@@ -77,16 +77,15 @@ class FusePlatformInstall extends InstallableItem {
     }).then(()=> {
         return this.headlessInstall(installer);
     }).then(()=> {
-      let devstudio = this.installerDataSvc.getInstallable('devstudio');
-      if(devstudio.installed) {
-        devstudio.configureRuntimeDetection('fuse-platform-on-eap', this.installerDataSvc.fuseplatformDir());
-      } else {
-        this.ipcRenderer.on('installComplete', (event, arg)=> {
-          if(arg == 'fusetools') {
+      this.ipcRenderer.on('installComplete', (event, arg)=> {
+        if(arg == 'all') {
+          let devstudio = this.installerDataSvc.getInstallable('devstudio');
+          if(devstudio.installed()) {
             devstudio.configureRuntimeDetection('fuse-platform-on-eap', this.installerDataSvc.fuseplatformDir());
           }
-        });
-      }
+        }
+      });
+
       installer.succeed(true);
     }).catch((error)=> {
       installer.fail(error);

--- a/browser/model/jbossfuse.js
+++ b/browser/model/jbossfuse.js
@@ -94,30 +94,36 @@ class FusePlatformInstall extends InstallableItem {
 
   headlessInstall(installer) {
     Logger.info(this.keyName + ' - headlessInstall() called');
-    let javaOpts = [
+    return installer.execFile(this.javaPath, this.installArgs, this.installOptions);
+  }
+
+  get installOptions() {
+    return {cwd: this.installerDataSvc.fuseplatformDir()};
+  }
+
+  get installArgs() {
+    return [
       '-jar',
       this.downloadedFile
     ];
-    let res = installer.execFile(
-      path.join(this.installerDataSvc.jdkDir(), 'bin', 'java'), javaOpts, {cwd: this.installerDataSvc.fuseplatformDir()}
-    );
-
-    return res;
   }
 
   headlessEapInstall(installer) {
     Logger.info(this.keyName + ' - headlessEapInstall() called');
-    let javaOpts = [
+    return installer.execFile(this.javaPath, this.eapInstallArgs);
+  }
+
+  get eapInstallArgs() {
+    return [
       '-DTRACE=true',
       '-jar',
       this.jbeap.downloadedFile,
       this.installConfigFile
     ];
-    let res = installer.execFile(
-      path.join(this.installerDataSvc.jdkDir(), 'bin', 'java'), javaOpts
-    );
+  }
 
-    return res;
+  get javaPath() {
+    return path.join(this.installerDataSvc.jdkDir(), 'bin', 'java');
   }
 }
 

--- a/browser/model/jbossfuse.js
+++ b/browser/model/jbossfuse.js
@@ -73,7 +73,9 @@ class FusePlatformInstall extends InstallableItem {
     return Promise.resolve().then(()=> {
       return installer.writeFile(this.installConfigFile, installGenerator(this.installerDataSvc.fuseplatformDir()));
     }).then(()=> {
-      return this.postJDKInstall(installer);
+        return this.headlessEapInstall(installer);
+    }).then(()=> {
+        return this.headlessInstall(installer);
     }).then(()=> {
       let devstudio = this.installerDataSvc.getInstallable('devstudio');
       if(devstudio.installed) {
@@ -91,42 +93,9 @@ class FusePlatformInstall extends InstallableItem {
     });
   }
 
-  postJDKInstall(installer) {
-    return new Promise((resolve, reject) => {
-      let jdkInstall = this.installerDataSvc.getInstallable(JdkInstall.KEY);
-      if (jdkInstall.isInstalled()) {
-        return Promise.resolve().then(()=> {
-          return this.headlessEapInstall(installer);
-        }).then(()=> {
-          return this.headlessInstall(installer);
-        }).then((res) => {
-          resolve(res);
-        }).catch((err) => {
-          reject(err);
-        });
-      } else {
-        Logger.info(this.keyName + ' - JDK has not finished installing, listener created to be called when it has.');
-        this.ipcRenderer.on('installComplete', (event, arg) => {
-          if (arg == JdkInstall.KEY) {
-            return Promise.resolve().then(()=> {
-              return this.headlessEapInstall(installer);
-            }).then(()=> {
-              return this.headlessInstall(installer);
-            }).then((res) => {
-              resolve(res);
-            }).catch((err) => {
-              reject(err);
-            });
-          }
-        });
-      }
-    });
-  }
-
   headlessInstall(installer) {
     Logger.info(this.keyName + ' - headlessInstall() called');
     let javaOpts = [
-      '-DTRACE=true',
       '-jar',
       this.downloadedFile
     ];

--- a/browser/model/jbossfusekaraf.js
+++ b/browser/model/jbossfusekaraf.js
@@ -43,16 +43,14 @@ class FusePlatformInstallKaraf extends InstallableItem {
           resolve();
         });
     }).then(()=> {
-      let devstudio = this.installerDataSvc.getInstallable('devstudio');
-      if(devstudio.installed) {
-        devstudio.configureRuntimeDetection('fuse-platform-on-karaf', this.installerDataSvc.fuseplatformkarafDir());
-      } else {
-        this.ipcRenderer.on('installComplete', (event, arg)=> {
-          if(arg == 'fusetools') {
+      this.ipcRenderer.on('installComplete', (event, arg)=> {
+        if(arg == 'all') {
+          let devstudio = this.installerDataSvc.getInstallable('devstudio');
+          if(devstudio.installed) {
             devstudio.configureRuntimeDetection('fuse-platform-on-karaf', this.installerDataSvc.fuseplatformkarafDir());
           }
-        });
-      }
+        }
+      });
       installer.succeed(true);
     }).catch((error)=> {
       installer.fail(error);

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -197,7 +197,7 @@ class JdkInstall extends InstallableItem {
   }
 
   isConfigured() {
-    if (Platform.getOS() === 'darwin') {
+    if (Platform.OS === 'darwin') {
       return this.isDetected() && this.option['detected'].valid;
     }
     return super.isConfigured();

--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -67,24 +67,26 @@ class ConfirmController {
   }
 
   installWatchers() {
-    let nodes = this.graph.overallOrder() ;
+    let graph = this.graph;
+    let nodes = graph.overallOrder() ;
+    let checkboxModel = this.sc.checkboxModel;
     for (let node of nodes) {
-      this.sc.checkboxModel[node].references=0;
+      checkboxModel[node].references=0;
     }
     for (let node of nodes) {
-      let watchComponent = ()=> {
-        let installer = this.sc.checkboxModel[node];
+      function watchComponent (){
+        let installer = checkboxModel[node];
         if(installer.isSelected()) {
-          for(let dep of this.graph.dependenciesOf(node)) {
-            let depInstaller = this.sc.checkboxModel[dep];
+          for(let dep of graph.dependenciesOf(node)) {
+            let depInstaller = checkboxModel[dep];
             if(depInstaller.references==0 && depInstaller.isNotDetected()) {
               depInstaller.selectedOption = 'install';
             }
             depInstaller.references++;
           }
         } else {
-          for(let dep of this.graph.dependenciesOf(node)) {
-            let depInstaller = this.sc.checkboxModel[dep];
+          for(let dep of graph.dependenciesOf(node)) {
+            let depInstaller = checkboxModel[dep];
             depInstaller.references--;
             if(depInstaller.references==0) {
               depInstaller.selectedOption = 'detected';

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -266,6 +266,7 @@ class InstallerDataService {
     if (!this.isDownloading() && this.toInstall.size == 0) {
       Logger.info('All installs complete');
       this.installing = false;
+      this.ipcRenderer.send('installComplete', 'all');
       this.router.go('start');
     }
   }

--- a/test/unit/model/fuseplatformkaraf-test.js
+++ b/test/unit/model/fuseplatformkaraf-test.js
@@ -108,11 +108,12 @@ describe('jbossplaformkaraf nstaller', function() {
       let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
       mockDevSuiteInstaller.emitEntries();
       return promise.then(()=>{
-        let devstudioInstaller = fuseInstaller.installerDataSvc.getInstallable('fusetools');
+        let devstudioInstaller = fuseInstaller.installerDataSvc.getInstallable('devstudio');
         expect(devstudioInstaller.configureRuntimeDetection).not.called;
-        fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'jdk');
+        fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'devstudio');
         expect(devstudioInstaller.configureRuntimeDetection).not.called;
-        fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'fusetools');
+        devstudioInstaller.installed = true;
+        fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'all');
         expect(devstudioInstaller.configureRuntimeDetection).calledOnce;
       });
     });

--- a/test/unit/model/jbosseap-test.js
+++ b/test/unit/model/jbosseap-test.js
@@ -40,6 +40,8 @@ describe('jbosseap installer', function() {
       jdk:{
         name: 'OpenJDK'
       }
+    }, {
+      version: 'X.0.0'
     }));
     ds.getRequirementByName.restore();
     ds.tempDir.returns('tempDirectory');

--- a/test/unit/model/jbosseap-test.js
+++ b/test/unit/model/jbosseap-test.js
@@ -242,65 +242,13 @@ describe('jbosseap installer', function() {
 
     it('should call success callback when installation is finished successfully', function() {
       sandbox.stub(Installer.prototype, 'writeFile').resolves();
-      sandbox.stub(installer, 'postJDKInstall').resolves();
+      sandbox.stub(installer, 'headlessInstall').resolves();
       sandbox.stub(Installer.prototype, 'succeed');
 
       return installer.installAfterRequirements(
         fakeProgress, function() {}, function() {}
       ).then(()=>{
         expect(Installer.prototype.succeed).to.be.calledWith(true);
-      });
-    });
-
-    describe('postJDKInstall', function() {
-      let helper, stubInstall, eventSpy;
-
-      beforeEach(function() {
-        helper = new Installer('jbosseap', fakeProgress, success, failure);
-        stubInstall = sandbox.stub(installer, 'headlessInstall').resolves(true);
-        eventSpy = installer.ipcRenderer.on;
-      });
-
-      it('should wait for JDK install to complete', function() {
-        return installer.postJDKInstall(helper, true)
-          .then(() => {
-            expect(eventSpy).calledOnce;
-          });
-      });
-
-      it('should wait for JDK install to complete and ignore other installed components', function() {
-        installer.ipcRenderer.on = sinon.stub();
-        installer.ipcRenderer.on.onFirstCall().yields({}, 'cdk');
-        sandbox.stub(fakeInstall, 'isInstalled').returns(false);
-        installer.postJDKInstall(helper, true);
-        expect(installer.ipcRenderer.on).has.been.called;
-        expect(stubInstall).has.not.been.called;
-      });
-
-      it('should call headlessInstall if JDK is installed', function() {
-        sandbox.stub(fakeInstall, 'isInstalled').returns(true);
-
-        return installer.postJDKInstall(
-          helper
-        ).then(() => {
-          expect(eventSpy).not.called;
-          expect(stubInstall).calledOnce;
-        });
-      });
-
-      it('should reject promise if headlessInstall fails', function() {
-        sandbox.stub(fakeInstall, 'isInstalled').returns(true);
-        installer.headlessInstall.restore();
-        stubInstall = sandbox.stub(installer, 'headlessInstall').rejects('Error');
-        return installer.postJDKInstall(
-          helper
-        ).then(() => {
-          expect.fail();
-        }).catch((error)=> {
-          expect(eventSpy).not.called;
-          expect(stubInstall).calledOnce;
-          expect(error.name).to.be.equal('Error');
-        });
       });
     });
 

--- a/test/unit/model/jbossfuse-test.js
+++ b/test/unit/model/jbossfuse-test.js
@@ -211,59 +211,6 @@ describe('fuseplatform installer', function() {
       }
     });
 
-    describe('postJDKInstall', function() {
-      let helper, stubInstall, eventSpy;
-
-      beforeEach(function() {
-        helper = new Installer('fuseplatform', fakeProgress, success, failure);
-        stubInstall = sandbox.stub(installer, 'headlessInstall').resolves(true);
-        stubInstall = sandbox.stub(installer, 'headlessEapInstall').resolves(true);
-        eventSpy = installer.ipcRenderer.on;
-      });
-
-      it('should wait for JDK install to complete', function() {
-        return installer.postJDKInstall(helper, true)
-          .then(() => {
-            expect(eventSpy).calledOnce;
-          });
-      });
-
-      it('should wait for JDK install to complete and ignore other installed components', function() {
-        installer.ipcRenderer.on = sinon.stub();
-        installer.ipcRenderer.on.onFirstCall().yields({}, 'cdk');
-        sandbox.stub(fakeInstall, 'isInstalled').returns(false);
-        installer.postJDKInstall(helper, true);
-        expect(installer.ipcRenderer.on).has.been.called;
-        expect(stubInstall).has.not.been.called;
-      });
-
-      it('should call headlessInstall if JDK is installed', function() {
-        sandbox.stub(fakeInstall, 'isInstalled').returns(true);
-
-        return installer.postJDKInstall(
-          helper
-        ).then(() => {
-          expect(eventSpy).not.called;
-          expect(stubInstall).calledOnce;
-        });
-      });
-
-      it('should reject promise if headlessInstall fails', function() {
-        sandbox.stub(fakeInstall, 'isInstalled').returns(true);
-        installer.headlessInstall.restore();
-        stubInstall = sandbox.stub(installer, 'headlessInstall').rejects('Error');
-        return installer.postJDKInstall(
-          helper
-        ).then(() => {
-          expect.fail();
-        }).catch((error)=> {
-          expect(eventSpy).not.called;
-          expect(stubInstall).calledOnce;
-          expect(error.name).to.be.equal('Error');
-        });
-      });
-    });
-
     describe('headlessInstall', function() {
       let helper;
       let child_process = require('child_process');
@@ -279,7 +226,6 @@ describe('fuseplatform installer', function() {
         let downloadedFile = path.join(installerDataSvc.tempDir(), files.platform.fileName);
         let javaPath = path.join(installerDataSvc.jdkDir(), 'bin', 'java');
         let javaOpts = [
-          '-DTRACE=true',
           '-jar',
           downloadedFile
         ];

--- a/test/unit/model/jbossfuse-test.js
+++ b/test/unit/model/jbossfuse-test.js
@@ -53,6 +53,8 @@ describe('fuseplatform installer', function() {
       devstudio:{
         name: 'Red Hat JBoss Developer Studio'
       }
+    }, {
+      version: 'X.0.0'
     }));
     ds.getRequirementByName.restore();
     ds.tempDir.returns('tempDirectory');

--- a/test/unit/model/jbossfusekaraf-test.js
+++ b/test/unit/model/jbossfusekaraf-test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import { default as sinonChai } from 'sinon-chai';
+import InstallerDataService from 'browser/services/data';
+import FusePlatformInstallKaraf from 'browser/model/jbossfusekaraf';
+import fs from 'fs';
+import path from 'path';
+import mkdirp from 'mkdirp';
+
+import EventEmitter from 'events';
+
+chai.use(sinonChai);
+
+describe('jbossplaformkaraf nstaller', function() {
+  let sandbox;
+  let fuseInstaller;
+  let fakeProgress;
+  let success;
+  let failure;
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+    fuseInstaller = new FusePlatformInstallKaraf(new InstallerDataService(), 'karaf', 'url', 'karaf.jar', 'sha256');
+    fuseInstaller.ipcRenderer = new EventEmitter();
+    sandbox.stub(mkdirp, 'sync').returns();
+    fakeProgress = {
+      setStatus: sandbox.stub(),
+      setComplete: sandbox.stub()
+    };
+    success = sandbox.stub();
+    failure = sandbox.stub();
+
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  function createInstallerMock(installed) {
+    let emitter = new EventEmitter();
+    let pipe = function() {
+      return emitter;
+    };
+    sandbox.stub(fs, 'createReadStream').returns({pipe});
+    sandbox.stub(fs, 'createWriteStream').callsFake(function(arg) {
+      return arg;
+    });
+    let entries = [
+      {
+        path: 'folder1/folder1',
+        type: 'Directory',
+        pipe: function() {},
+        autodrain: function() {}
+
+      }, {
+        path: 'folder1/folder2/file1',
+        type: 'File',
+        pipe: function() {},
+        autodrain: function() {}
+      },
+    ];
+    sandbox.stub(fuseInstaller.installerDataSvc, 'fuseplatformkarafDir').returns('fusekaraf');
+    sandbox.stub(fuseInstaller.installerDataSvc, 'getInstallable').returns({
+      installed: installed,
+      configureRuntimeDetection: sandbox.stub()
+    });
+    function emitEntries() {
+      for(let entry of entries) {
+        emitter.emit('entry', entry);
+      }
+      emitter.emit('close');
+    }
+    function emitError(error) {
+      emitter.emit('error', error);
+    }
+    return {
+      emitEntries,
+      emitError
+    };
+  }
+
+  describe('installAfterRequirements', function() {
+    it('should remove first level folder when unpack direcories from zip archive', function() {
+      let mockDevSuiteInstaller = createInstallerMock(true);
+      let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
+      mockDevSuiteInstaller.emitEntries();
+      return promise.then(()=>{
+        expect(mkdirp.sync).calledOnce;
+        expect(mkdirp.sync).calledWith(
+          path.join(fuseInstaller.installerDataSvc.fuseplatformkarafDir(), 'folder1')
+        );
+      });
+    });
+    it('should remove first level folder when unpack files from zip archive', function() {
+      let mockDevSuiteInstaller = createInstallerMock(false);
+      let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
+      mockDevSuiteInstaller.emitEntries();
+      return promise.then(()=>{
+        expect(fs.createWriteStream).calledWith(
+          path.join(fuseInstaller.installerDataSvc.fuseplatformkarafDir(), 'folder2', 'file1')
+        );
+      });
+    });
+    it('should configure runtime detection after devstudio installation finished', function() {
+      let mockDevSuiteInstaller = createInstallerMock(false);
+      let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
+      mockDevSuiteInstaller.emitEntries();
+      return promise.then(()=>{
+        let devstudioInstaller = fuseInstaller.installerDataSvc.getInstallable('devstudio');
+        expect(devstudioInstaller.configureRuntimeDetection).not.called;
+        fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'devstudio');
+        expect(devstudioInstaller.configureRuntimeDetection).not.called;
+        devstudioInstaller.installed = true;
+        fuseInstaller.ipcRenderer.emit('installComplete', 'installComplete', 'all');
+        expect(devstudioInstaller.configureRuntimeDetection).calledOnce;
+      });
+    });
+    it('should return rejected promice if exception cought during unpacking', function() {
+      let mockDevSuiteInstaller = createInstallerMock(false);
+      mkdirp.sync.restore();
+      sandbox.stub(mkdirp, 'sync').throws('Error');
+      let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
+      mockDevSuiteInstaller.emitEntries();
+      return promise.then(()=>{
+        expect.fail();
+      }).catch((error)=> {
+        expect(error.name).equals('Error');
+      });
+    });
+    it('should return rejected promise if unzip-stream emitted error', function() {
+      let mockDevSuiteInstaller = createInstallerMock(false);
+      let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
+      mockDevSuiteInstaller.emitError('Error');
+      return promise.then(()=>{
+        expect.fail();
+      }).catch((error)=> {
+        expect(error).equals('Error');
+      });
+    });
+  });
+});

--- a/test/unit/pages/confirm/controller-test.js
+++ b/test/unit/pages/confirm/controller-test.js
@@ -149,8 +149,15 @@ describe('ConfirmController', function() {
         expect(confirmController.router.go).calledOnce;
       });
     });
+  });
 
+  describe('dependency resolution', function() {
+    beforeEach(function() {
+      sandbox.stub(Platform, 'getOS').returns('win32');
+    });
+    beforeEach(inject(context));
     it('should deselect openjdk if jbosseap and devstudio are not selected', function() {
+      debugger;
       return confirmController.initPage().then(function() {
         expect(confirmController.sc.checkboxModel.jdk.selectedOption).equals('install');
         $watch.args.forEach(function(el) {

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -341,9 +341,10 @@ describe('InstallerDataService', function() {
       svc.setupDone(fakeProgress, 'jdk');
       svc.setupDone(fakeProgress, 'vbox');
 
-      expect(spy).calledTwice;
+      expect(spy).calledThrice;
       expect(spy).calledWith('installComplete', 'jdk');
       expect(spy).calledWith('installComplete', 'vbox');
+      expect(spy).calledWith('installComplete', 'all');
     });
 
     it('setupDone should switch to final page when all installs have finished', function() {


### PR DESCRIPTION
This fix:
1. Removes not deeded listeners for cmponents required OpenJDK
   to be installed first, because install ordering is already taking
   care of it
2. Fix unit test errors under macOS