### PR TITLE
Make failed download progress bar look like a proper failure

### DIFF
--- a/browser/directives/progressBar.html
+++ b/browser/directives/progressBar.html
@@ -9,12 +9,12 @@
         <div class="progress-status">
           <div ng-class="{'spinner spinner-xs spinner-inline' : progress.status == 'Installing' || progress.status == 'Downloading' || progress.status == 'Setting up' || progress.status.indexOf('Waiting') > -1 || progress.status.indexOf('Verifying') > -1,
                           'pficon pficon-ok': progress.status == 'Complete',
-                          'pficon-error-circle-o': progress.status == 'Failed'}"></div>
+                          'pficon-error-circle-o': progress.status.indexOf('Failed') > -1}"></div>
           <strong>{{progress.status}}</strong>
         </div>
         <div class="progress progress-label-top-right">
           <div class="progress-bar"
-            ng-class="{'progress-bar-striped active': progress.status == 'Installing' || progress.status == 'Setting up' || progress.status.indexOf('Waiting') > -1 || progress.status.indexOf('Verifying') > -1, 'progress-bar-danger': progress.status == 'Failed'}"
+            ng-class="{'progress-bar-striped active': progress.status == 'Installing' || progress.status == 'Setting up' || progress.status.indexOf('Waiting') > -1 || progress.status.indexOf('Verifying') > -1, 'progress-bar-danger': progress.status.indexOf('Failed') > -1}"
             role="progressbar" aria-valuenow="{{progress.current}}" aria-valuemin="{{progress.min}}" aria-valuemax="{{progress.max}}"
             style="width: {{progress.current}}%; animation: progress-bar-stripes 2s infinite steps(15);">
             <span>{{progress.label}}</span>

--- a/browser/pages/install/controller.js
+++ b/browser/pages/install/controller.js
@@ -40,7 +40,7 @@ class InstallController {
       },
       (error) => {
         Logger.error(installableKey + ' failed to download: ' + error);
-        progress.setStatus('Download failed');
+        progress.setStatus('Download Failed');
         this.failedDownloads.add(installableValue);
       }
     );

--- a/test/unit/pages/install/controller-test.js
+++ b/test/unit/pages/install/controller-test.js
@@ -445,7 +445,7 @@ describe('Install controller', function() {
       let installCtrl = new InstallController(scopeStub, timeoutStub, installerDataSvc);
       installCtrl.status('virtualbox');
       expect(InstallableItem.prototype.downloadInstaller).calledOnce;
-      expect(installCtrl.status('virtualbox')).to.equal('Download failed');
+      expect(installCtrl.status('virtualbox')).to.equal('Download Failed');
     });
   });
 });


### PR DESCRIPTION
It should suggest a failure just like the failed installation. Hence it should look like a failure, including the new fancy icon and colours.