### PR TITLE
Hide void/zero file sizes

### DIFF
--- a/browser/directives/componentPanel.html
+++ b/browser/directives/componentPanel.html
@@ -26,7 +26,7 @@
           </div>
         </div>
         <span id="{{item.keyName}}-name" class="product-name">{{item.productName}}</span>
-        <span id="{{item.keyName}}-version" class="product-info">{{item.version}}</span><span class="product-info">|</span><span id="{{item.keyName}}-size" class="product-info">{{item.size}}</span>
+        <span id="{{item.keyName}}-version" class="product-info">{{item.version}}</span><span ng-show="parseNumber(item.size) > 0"><span class="product-info">|</span><span id="{{item.keyName}}-size" class="product-info">{{item.size}}</span></span>
         <div id="{{item.keyName}}-description">{{item.productDesc}}</div>
       </div>
     </div>

--- a/browser/directives/componentPanel.js
+++ b/browser/directives/componentPanel.js
@@ -11,6 +11,10 @@ function componentPanel() {
         let evaluate = new Function('installerDataSvc', 'return ' + content);
         return evaluate(installerDataSvc);
       };
+
+      $scope.parseNumber = function(string) {
+        return parseFloat(string);
+      };
     }]),
     restrict: 'E',
     replace: true,

--- a/test/ui/confirm-test.js
+++ b/test/ui/confirm-test.js
@@ -58,7 +58,7 @@ describe('Confirm page', function confimPage() {
           requirements[key].panel = element(By.id(key + '-panel'));
           requirements[key].nameElement = element(By.id(key + '-name'));
           requirements[key].versionElement = element(By.id(key + '-version'));
-          requirements[key].sizeElement = element(By.id(key + '-size'));                    
+          requirements[key].sizeElement = element(By.id(key + '-size'));
           requirements[key].descriptionElement = element(By.id(key + '-description'));
 
           if(key === 'virtualbox') {
@@ -137,9 +137,13 @@ function testComponentPanel(key) {
     });
 
     it('should display a correct size', function() {
-      expect(component.sizeElement.isDisplayed()).toBe(true);
-      expect(component.sizeElement.getText()).toEqual(humanize.filesize(component.size));
-    }); 
+      if (component.size > 0) {
+        expect(component.sizeElement.isDisplayed()).toBe(true);
+        expect(component.sizeElement.getText()).toEqual(humanize.filesize(component.size));
+      } else {
+        expect(component.sizeElement.isDisplayed()).toBe(false);
+      }
+    });
 
     it('should display a correct description', function() {
       expect(component.descriptionElement.isDisplayed()).toBe(true);


### PR DESCRIPTION
Items like hyper-v have no use for file sizes, so it feels better not to show them, rather than use 0.00 PB