### PR TITLE
Fix help menu not appearing on mac

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -90,10 +90,15 @@ let template = [
   },
   {
     label: 'Help',
-    accelerator: 'f1',
-    click: () => {
-      require('electron').shell.openExternal('https://access.redhat.com/documentation/en/red-hat-development-suite/');
-    }
+    submenu: [
+      {
+        label: 'Documentation',
+        accelerator: 'f1',
+        click: () => {
+          require('electron').shell.openExternal('https://access.redhat.com/documentation/en/red-hat-development-suite/');
+        }
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
looks like mac menu does not support entries without submenus, so I added one for Help