### PR TITLE
JBDS-4310 Verify what resources is already downloaded

### DIFF
--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -62,7 +62,6 @@ class InstallableItem {
           this.downloaded = stat && (stat.size == requirement.size);
         } catch (error) {
           Logger.info(`${this.keyName} - fstat function failure ${error}`);
-          console.log(error);
         }
       }
     }

--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -53,6 +53,20 @@ class InstallableItem {
     mkdirp.sync(this.downloadFolder);
     this.downloadedFile = path.join(this.downloadFolder, fileName);
 
+    if(fs.existsSync(this.bundledFile)) {
+      this.downloaded = true;
+    } else {
+      if(fs.existsSync(this.downloadedFile)) {
+        try {
+          let stat = fs.statSync(this.downloadedFile);
+          this.downloaded = stat && (stat.size == requirement.size);
+        } catch (error) {
+          Logger.info(`${this.keyName} - fstat function failure ${error}`);
+          console.log(error);
+        }
+      }
+    }
+
     this.installAfter = undefined;
     this.ipcRenderer = ipcRenderer;
     this.authRequired = authRequired;


### PR DESCRIPTION
Fix adds check for downloaded resources based on file size.
SHA256 sum verification is done later during installation.
Checking file size is much faster than calculating SHA256
for every downloaded file.