### PR TITLE
JBDS-4575 Move persistent changes to the start of installation

### DIFF
--- a/browser/pages/install/controller.js
+++ b/browser/pages/install/controller.js
@@ -10,6 +10,7 @@ class InstallController {
     this.$timeout = $timeout;
     this.installerDataSvc = installerDataSvc;
     this.failedDownloads = new Set();
+    this.installerDataSvc.setupTargetFolder();
 
     this.data = {};
     for (var [key, value] of this.installerDataSvc.allInstallables().entries()) {

--- a/browser/pages/location/controller.js
+++ b/browser/pages/location/controller.js
@@ -27,7 +27,9 @@ class LocationController {
   }
 
   resetFolder() {
-    this.folder = this.installerDataSvc.defaultFolder;
+    if (!this.folder) {
+      this.folder = this.installerDataSvc.defaultFolder;
+    }
   }
 
   selectFolder() {

--- a/browser/pages/selection/controller.js
+++ b/browser/pages/selection/controller.js
@@ -179,7 +179,7 @@ class SelectionController {
     this.electron.remote.getCurrentWindow().removeAllListeners('focus');
     this.installerDataSvc.setup(...possibleComponents);
 
-    this.router.go(this.next());
+    this.next();
   }
 
   next() {

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -73,7 +73,9 @@ class InstallerDataService {
     this.cdkBoxRoot = this.cdkRoot;
     this.ocBinRoot = path.join(this.cdkRoot, 'bin');
     this.cdkMarkerFile = path.join(this.cdkRoot, '.cdk');
+  }
 
+  setupTargetFolder() {
     if (!fs.existsSync(this.installRoot)) {
       mkdirp.sync(path.resolve(this.installRoot));
     }

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -142,6 +142,7 @@ describe('InstallerDataService', function() {
 
       it('should copy uninstaller powershell script to target install folder', function() {
         svc.setup();
+        svc.setupTargetFolder();
         expect(svc.copyUninstaller).calledOnce;
       });
 
@@ -149,13 +150,15 @@ describe('InstallerDataService', function() {
         fxExtraStub.yields('error');
         Logger.error.reset();
         svc.setup();
+        svc.setupTargetFolder();
         expect(Logger.error).calledOnce;
       });
 
-      it('should log sucess message if copy operation succed', function() {
+      it('should log sucess message if copy operation succeeded', function() {
         fxExtraStub.yields();
         Logger.info.reset();
         svc.setup();
+        svc.setupTargetFolder();
         expect(Logger.info).calledTwice;
       });
 
@@ -172,6 +175,7 @@ describe('InstallerDataService', function() {
           resolve();
         });
         svc.setup();
+        svc.setupTargetFolder();
         return result.then(()=>{
           expect(child_process.exec).to.be.called;
           expect(Logger.info).calledThrice;
@@ -192,6 +196,7 @@ describe('InstallerDataService', function() {
           resolve();
         });
         svc.setup();
+        svc.setupTargetFolder();
         return result.then(()=>{
           expect(child_process.exec).to.be.called;
         });


### PR DESCRIPTION
target folder, logs and registry items should be created after the point of no return. Moving them from after selection page to the start of the installation.