### PR TITLE
Fix #908 Weird progress status

### DIFF
--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -187,7 +187,6 @@ class InstallableItem {
       this.installAfterRequirements(progress, success, failure);
     } else {
       let name = this.getInstallAfter().productName;
-      progress.setStatus(`Waiting for ${name} to finish installation`);
       this.ipcRenderer.on('installComplete', (event, arg) => {
         if (!this.isInstalled() && arg === this.getInstallAfter().keyName) {
           progress.productName = this.productName;

--- a/test/unit/model/cygwin-test.js
+++ b/test/unit/model/cygwin-test.js
@@ -145,18 +145,6 @@ describe('Cygwin installer', function() {
       installerDataSvc.getRequirementByName.returns(reqs.cygwin);
     });
 
-    it('should not start until virtualbox has finished installing', function() {
-      let installSpy = sandbox.spy(installer, 'installAfterRequirements');
-      let item2 = new InstallableItem('virtualbox', 'url', 'installFile', 'targetFolderName', installerDataSvc);
-      item2.thenInstall(installer);
-
-      installer.install(fakeProgress, success, failure);
-
-      expect(installSpy).not.called;
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Waiting for Oracle VirtualBox to finish installation');
-    });
-
     it('should install once virtualbox has finished', function() {
       let stub = sandbox.stub(installer, 'installAfterRequirements').returns();
       sandbox.stub(fakeInstallable, 'isInstalled').returns(true);

--- a/test/unit/model/devstudio-test.js
+++ b/test/unit/model/devstudio-test.js
@@ -150,26 +150,6 @@ describe('devstudio installer', function() {
 
     let fsextra = require('fs-extra');
 
-    describe('on windows', function() {
-      beforeEach(function() {
-        sandbox.stub(Platform, 'getOS').returns('win32');
-      });
-
-      it('should not start until JDK has finished installing', function() {
-        let installerDataSvc = stubDataService();
-        installer.ipcRenderer = { on: function() {} };
-        let installSpy = sandbox.spy(installer, 'installAfterRequirements');
-        let item2 = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', installerDataSvc);
-        item2.thenInstall(installer);
-
-        installer.install(fakeProgress, success, failure);
-
-        expect(installSpy).not.called;
-        expect(fakeProgress.setStatus).to.have.been.calledOnce;
-        expect(fakeProgress.setStatus).to.have.been.calledWith('Waiting for OpenJDK to finish installation');
-      });
-    });
-
     it('should install once JDK has finished', function() {
       let stub = sandbox.stub(installer, 'installAfterRequirements').returns();
       sandbox.stub(fakeInstall, 'isInstalled').returns(true);

--- a/test/unit/model/jbosseap-test.js
+++ b/test/unit/model/jbosseap-test.js
@@ -174,26 +174,6 @@ describe('jbosseap installer', function() {
 
     let fsextra = require('fs-extra');
 
-    describe('on windows', function() {
-      beforeEach(function() {
-        sandbox.stub(Platform, 'getOS').returns('win32');
-      });
-
-      it('should not start until JDK has finished installing', function() {
-        let installerDataSvc = stubDataService();
-        installer.ipcRenderer = { on: function() {} };
-        let installSpy = sandbox.spy(installer, 'installAfterRequirements');
-        let item2 = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', installerDataSvc);
-        item2.thenInstall(installer);
-
-        installer.install(fakeProgress, success, failure);
-
-        expect(installSpy).not.called;
-        expect(fakeProgress.setStatus).to.have.been.calledOnce;
-        expect(fakeProgress.setStatus).to.have.been.calledWith('Waiting for OpenJDK to finish installation');
-      });
-    });
-
     it('should install once JDK has finished', function() {
       let stub = sandbox.stub(installer, 'installAfterRequirements').returns();
       sandbox.stub(fakeInstall, 'isInstalled').returns(true);

--- a/test/unit/model/jbossfuse-test.js
+++ b/test/unit/model/jbossfuse-test.js
@@ -168,20 +168,6 @@ describe('fuseplatform installer', function() {
       sandbox.stub(Installer.prototype, 'copyFile').resolves();
     });
 
-    it('should not start until devstudio has finished installing', function() {
-      let installerDataSvc = stubDataService();
-      installer.ipcRenderer = { on: function() {} };
-      let installSpy = sandbox.spy(installer, 'installAfterRequirements');
-      let item2 = new InstallableItem('devstudio', 'url', 'installFile', 'targetFolderName', installerDataSvc);
-      item2.thenInstall(installer);
-
-      installer.install(fakeProgress, success, failure);
-
-      expect(installSpy).not.called;
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Waiting for Red Hat JBoss Developer Studio to finish installation');
-    });
-
     it('should install once devstudio has finished', function() {
       let stub = sandbox.stub(installer, 'installAfterRequirements').returns();
       sandbox.stub(fakeInstall, 'isInstalled').returns(true);


### PR DESCRIPTION
Removes waiting for ${name} to finish installation message
from install method, because new implementation install
components one by one.