### PR TITLE
Fix #909 Downloaded components posing as not downloaded

### DIFF
--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -50,7 +50,9 @@ class InstallableItem {
 
     this.downloader = null;
     this.downloadFolder = path.join(this.installerDataSvc.localAppData(), 'cache');
-    mkdirp.sync(this.downloadFolder);
+    if(!fs.existsSync(this.downloadFolder)) {
+      mkdirp.sync(this.downloadFolder);
+    }
     this.downloadedFile = path.join(this.downloadFolder, fileName);
 
     if(fs.existsSync(this.bundledFile)) {


### PR DESCRIPTION
Check if download cache file doe not exist before
creating it to avoid problems on macOS.
![image](https://user-images.githubusercontent.com/620330/31564794-378e4a56-b019-11e7-853a-68439865ebd0.png)
