### PR TITLE
Replace 'download size' to 'amount' throughout install controller

### DIFF
--- a/browser/pages/install/controller.js
+++ b/browser/pages/install/controller.js
@@ -13,7 +13,7 @@ class InstallController {
     this.installerDataSvc = installerDataSvc;
     this.electron = electron;
     this.failedDownloads = new Set();
-    this.totalSize = 0;
+    this.totalAmount = 0;
     this.installerDataSvc.setupTargetFolder();
 
     this.data = {};
@@ -23,7 +23,7 @@ class InstallController {
         if(value.isDownloadRequired()) {
           this.totalDownloads += value.totalDownloads;
         }
-        this.totalSize += value.size;
+        this.totalAmount += value.size;
       }
     }
     this.itemProgress = new ProgressState('', undefined, undefined, undefined, this.$scope, this.$timeout);
@@ -40,7 +40,7 @@ class InstallController {
       },
       this.totalDownloads
     );
-    this.itemProgress.setTotalDownloadSize(this.totalSize);
+    this.itemProgress.setTotalAmount(this.totalAmount);
     for (let [key, value] of this.installerDataSvc.allInstallables().entries()) {
       if(value.isSkipped()) {
         this.installerDataSvc.setupDone(this.itemProgress, key);
@@ -128,7 +128,7 @@ const shortDuration = {
 };
 
 class ProgressState {
-  constructor(key, productName, productVersion, productDesc, $scope, $timeout = function(){}, minValue=0, maxValue=100) {
+  constructor(key, productName, productVersion, productDesc, $scope, $timeout = function() {}, minValue=0, maxValue=100) {
     this.key = key;
     this.productName = productName;
     this.productVersion = productVersion;
@@ -140,7 +140,7 @@ class ProgressState {
     this.status = '';
     this.currentAmount = 0;
     this.lastAmount = 0;
-    this.totalSize = 0;
+    this.totalAmount = 0;
     this.min = minValue;
     this.max = maxValue;
     this.lastTime = Date.now();
@@ -149,12 +149,12 @@ class ProgressState {
     this.durationFormat.units = ['y', 'd', 'h', 'm'];
   }
 
-  setTotalDownloadSize(size) {
-    this.totalSize = size;
+  setTotalAmount(size) {
+    this.totalAmount = size;
   }
 
   setCurrent(newVal) {
-    if (newVal > this.currentAmount && newVal <= this.totalSize) {
+    if (newVal > this.currentAmount && newVal <= this.totalAmount) {
       this.lastAmount = this.currentAmount;
       this.currentAmount = newVal;
 
@@ -163,8 +163,8 @@ class ProgressState {
         this.durationFormat.units.push('s');
       }
 
-      this.current = Math.round(this.currentAmount / this.totalSize * 100);
-      this.label = this.sizeInKB(this.currentAmount) + ' / ' + this.sizeInKB(this.totalSize) + ' (' + this.current + '%), ' + this.durationFormat(remaining) + ' left';
+      this.current = Math.round(this.currentAmount / this.totalAmount * 100);
+      this.label = this.sizeInKB(this.currentAmount) + ' / ' + this.sizeInKB(this.totalAmount) + ' (' + this.current + '%), ' + this.durationFormat(remaining) + ' left';
       this.$timeout();
     }
   }
@@ -175,7 +175,7 @@ class ProgressState {
     this.lastTime = currentTime;
     this.averageSpeed = this.averageSpeed === 0 ? this.lastSpeed : smoothFactor * this.lastSpeed + (1 - smoothFactor) * this.averageSpeed;
 
-    return (this.totalSize - this.currentAmount) / this.averageSpeed;
+    return (this.totalAmount - this.currentAmount) / this.averageSpeed;
   }
 
   setStatus(newStatus) {
@@ -189,7 +189,7 @@ class ProgressState {
       this.current = 0;
       this.label = 0 + '%';
       this.currentAmount = 0;
-      //    this.totalSize = 0;
+      //    this.totalAmount = 0;
     }
     this.status = newStatus;
     this.$timeout();

--- a/test/unit/pages/install/controller-test.js
+++ b/test/unit/pages/install/controller-test.js
@@ -168,8 +168,8 @@ describe('Install controller', function() {
     describe('setTotalDownloadSize', function() {
       it('should set totalSize property value', function() {
         let progress = new ProgressState();
-        progress.setTotalDownloadSize(1000);
-        expect(progress.totalSize).to.be.equal(1000);
+        progress.setTotalAmount(1000);
+        expect(progress.totalAmount).to.be.equal(1000);
       });
     });
     describe('setCurrent', function() {
@@ -185,7 +185,7 @@ describe('Install controller', function() {
           progress = new ProgressState();
           progress.$timeout = sinon.stub();
           progress.$scope = {$apply:sinon.stub()};
-          progress.setTotalDownloadSize(1000);
+          progress.setTotalAmount(1000);
           progress.setCurrent(100);
         });
         it('current progress amount value', function() {
@@ -196,7 +196,7 @@ describe('Install controller', function() {
         });
         it('lable value', function() {
           expect(progress.label).to.have.string(
-            progress.sizeInKB(progress.currentAmount) + ' / ' + progress.sizeInKB(progress.totalSize) + ' (' + progress.current + '%)'
+            progress.sizeInKB(progress.currentAmount) + ' / ' + progress.sizeInKB(progress.totalAmount) + ' (' + progress.current + '%)'
           );
         });
         it('ETA to second', function() {
@@ -285,7 +285,7 @@ describe('Install controller', function() {
         progress = new ProgressState();
         progress.$timeout = sinon.stub();
         progress.$scope = {$apply:sinon.stub()};
-        progress.setTotalDownloadSize(1000);
+        progress.setTotalAmount(1000);
         progress.setCurrent(100);
         progress.setComplete();
       });
@@ -304,7 +304,7 @@ describe('Install controller', function() {
       beforeEach(function() {
         progress = new ProgressState();
         progress.lastTime = 100000;
-        progress.totalSize = 9000000;
+        progress.totalAmount = 9000000;
         progress.currentAmount = 400000;
         sandbox.stub(Date.prototype, 'getTime').returns(101000);
       });


### PR DESCRIPTION
Current progress holder is intended to report download progress
only. This commit makes it generic and replaces 'download size'
related names to just 'amount' throughout installation page controller.