### PR TITLE
Fix #922 Fuse Tooling appears as 'Selected to download' on conf page

### DIFF
--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -116,6 +116,14 @@ class InstallableItem {
     this.downloaded = true;
   }
 
+  getDownloadStatus() {
+    let status = 'No download required';
+    if (this.size && this.size >= 0) {
+      status = this.downloaded ? 'Previously Downloaded' : 'Selected to download';
+    }
+    return status;
+  }
+
   setInstallComplete() {
     this.installed = true;
   }

--- a/browser/pages/confirm/confirm.html
+++ b/browser/pages/confirm/confirm.html
@@ -27,7 +27,7 @@
             >
               <span ng-class="{'pficon pficon-ok': component.downloaded, 'fa fa-download info-color': !component.downloaded}"></span>
               <strong id="{{component.keyName}}-name">&nbsp;{{component.productName}}</strong><span id="{{component.keyName}}-version" class="product-info">| {{component.productVersion}}</span>
-              <strong id="{{component.keyName}}-download-status" class="pull-right">{{component.downloaded ? 'Previously downloaded' : 'Selected to download'}}</strong>
+              <strong id="{{component.keyName}}-download-status" class="pull-right">{{component.getDownloadStatus()}}</strong>
             </div>
           </div>
         </div>

--- a/requirements.json
+++ b/requirements.json
@@ -173,7 +173,7 @@
     "installAfter": "devstudio",
     "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/devstudio-11.0.0.GA-installer-standalone.jar?workflow=direct",
     "url": "https://devstudio.redhat.com/11/staging/builds/devstudio-11.0.0.GA-build-product/2017-08-09_05-02-53-B748/all/devstudio-11.0.0.GA-installer-standalone.jar",
-    "fileName": "devstudio-11.0.0.GA-installer-standalone.jar",
+    "fileName": "devstudio-11.1.0.GA-installer-standalone.jar",
     "sha256sum": "",
     "version": "10.0.0.GA",
     "additionalLocation": "",


### PR DESCRIPTION
Use 'No download required' for components with size equals undefined
or 0.