### PR TITLE
Fix #930 Hyper-V Administrators group localization issue

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -44,11 +44,12 @@ class CDKInstall extends InstallableItem {
       let hv = this.installerDataSvc.getInstallable('hyperv');
       if (hv && hv.hasOption('detected')) {
         driverName = 'hyperv';
-        return installer.exec(
-          'net localgroup "Hyper-V Administrators" %USERDOMAIN%\\%USERNAME% /add'
-        ).catch(()=>Promise.resolve());
+        return Platform.getHypervAdminsGroupName().then((group)=>{
+          installer.exec(
+            `net localgroup "${group}" %USERDOMAIN%\\%USERNAME% /add`
+          ).catch(()=>{});
+        });
       }
-      return Promise.resolve();
     }).then(()=> {
       return installer.exec(
         `${minishiftExe} stop`

--- a/browser/services/platform.js
+++ b/browser/services/platform.js
@@ -37,6 +37,19 @@ class Platform {
     });
   }
 
+  static getHypervAdminsGroupName() {
+    return Platform.identify({
+      win32: function() {
+        return pify(child_process.exec)('powershell -ExecutionPolicy ByPass -command "(New-Object System.Security.Principal.SecurityIdentifier(\'S-1-5-32-578\')).Translate([System.Security.Principal.NTAccount]).Value;[Environment]::Exit(0);"').then((stdout)=>{
+          return stdout ? stdout.trim().replace('BUILTIN\\', '') : '';
+        }).catch(function() {});
+      },
+      default: function() {
+        return Promise.resolve();
+      }
+    });
+  }
+
   static isVirtualizationEnabled() {
     return Platform.identify({
       win32: function() {

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -285,8 +285,11 @@ describe('CDK installer', function() {
 
       it('should add current user to `Hyper-V Administrators` group when hyper-v is detected', function() {
         Installer.prototype.exec.restore();
+        child_process.exec.restore();
+        sandbox.stub(child_process, 'exec').yields(undefined, 'BUILTIN\\Hyper-V Administrators');
         sandbox.stub(Installer.prototype, 'exec').onCall(0).rejects('Error');
         Installer.prototype.exec.onCall(1).resolves();
+
         let hyperv = new InstallableItem('hyperv', 'url', 'hypev.exe', 'hyperv', svc, false);
         svc.addItemsToInstall(hyperv);
         hyperv.addOption('detected', '1.0.0', 'hyperv', true);
@@ -294,7 +297,8 @@ describe('CDK installer', function() {
           installer.installAfterRequirements(fakeProgress, resolve, reject);
         }).then(()=>{
           expect(Installer.prototype.exec).calledWith('net localgroup "Hyper-V Administrators" %USERDOMAIN%\\%USERNAME% /add');
-        }).catch(()=>{
+        }).catch((error)=>{
+          console.log(error);
           expect.fail();
         });
       });


### PR DESCRIPTION
Local group names are localized on windows and therefore to support windows installations with different locale CDK installer cannot use 'Hyper-V Administrators' group name when adding current user into it using `net localgroup` command. First it should get localized name by SID (security identifier) for the group using powershell script.