### PR TITLE
Fix #952 breadcrumb and component scrolling layout

### DIFF
--- a/browser/app.css
+++ b/browser/app.css
@@ -814,18 +814,28 @@ footer {
     position: fixed;
     width: 794px;
     background: #fff;
-    border-bottom: 2px solid #d1d1d1;
-    margin: 0 -15px 20px;
-    padding: 10px 5px 5px;
+    border-bottom: 4px solid #cde7f8;
+    margin: 0 -15px 0;
+    padding: 20px 5px 5px;
     border-top: 2px solid #fafafa;
+  }
+
+  .confirm-heading-title {
+    font-size: 16px;
+    font-weight: 700;
   }
 
   .inline {
     display: inline-block;
   }
 
-  .confirm-margin {
-    margin: 120px 0 0;
+  .confirm-summary-list {
+    padding: 110px 0 20px;
+  }
+
+  .confirm-summary-note {
+    padding: 10px 0 10px 0;
+    color: #0088ce;
   }
 
   .install-desc {
@@ -851,7 +861,7 @@ footer {
     background: #fff;
     border-top: 2px solid transparent;
     padding: 0 10px;
-    margin-top: 40px;
+    margin: 10px 50px 0 50px;
   }
 
   .confirm-card-margin {

--- a/browser/pages/confirm/confirm.html
+++ b/browser/pages/confirm/confirm.html
@@ -4,34 +4,29 @@
 
 <main>
   <div class="bottom-spacer container-fluid container-cards-pf">
-    <div class="row row-cards-pf confirm-card-margin">
-      <div class="col-xs-12 col-sm-12">
-        <div class="confirm-layout">
-          <div class="confirm-heading">
-            <h2 id="confirm-summary-title" class="card-pf-title inline">
-              Confirmation Summary
-            </h2>
-            <div class="size-summary pull-right">
-              <span id="confirm-download-size" class="size-note">Total Download Size:&nbsp;</span><strong id="download-size-header">{{updateTotalDownloadSize() | humanize}}</strong>
-              <div class="install-desc">
-                <span id="confirm-install-size" class="size-note">Total Install Size:&nbsp;</span><strong id="install-size-header">{{updateTotalInstallSize() | humanize}}</strong>
-              </div>
-            </div>
-            <div class="info-color">
-              <i class="pficon-info" aria-hidden="true"></i>
-              <span id="confirm-note">Please verify the confirmation summary. Click <b>{{confCtrl.getNextButtonName()}}</b> to begin installation.</span>
+    <div class="col-xs-12 col-sm-12">
+      <div class="confirm-layout">
+        <div class="confirm-heading">
+          <span id="confirm-summary-title" class="confirm-heading-title">Confirmation Summary</span>
+          <div class="size-summary pull-right">
+            <span id="confirm-download-size" class="size-note">Total Download Size:&nbsp;</span><strong id="download-size-header">{{updateTotalDownloadSize() | humanize}}</strong>
+            <div class="install-desc">
+              <span id="confirm-install-size" class="size-note">Total Install Size:&nbsp;</span><strong id="install-size-header">{{updateTotalInstallSize() | humanize}}</strong>
             </div>
           </div>
-          <div class="card-pf-body confirm-margin">
-            <div ng-repeat="component in downloadComp | orderBy: '-downloaded'" class="summary-info" id="{{component.keyName}}-info"
-            >
-              <span ng-class="{'pficon pficon-ok': component.downloaded, 'fa fa-download info-color': !component.downloaded}"></span>
-              <strong id="{{component.keyName}}-name">&nbsp;{{component.productName}}</strong><span id="{{component.keyName}}-version" class="product-info">| {{component.productVersion}}</span>
-              <strong id="{{component.keyName}}-download-status" class="pull-right">{{component.getDownloadStatus()}}</strong>
-            </div>
+          <div class="confirm-summary-note">
+            <i class="pficon-info" aria-hidden="true"></i>
+            <span id="confirm-note">Please verify the confirmation summary. Click <b>{{confCtrl.getNextButtonName()}}</b> to begin installation.</span>
           </div>
         </div>
-
+        <div class="confirm-summary-list">
+          <div ng-repeat="component in downloadComp | orderBy: '-downloaded'" class="summary-info" id="{{component.keyName}}-info">
+            <span ng-class="{'pficon pficon-ok': component.downloaded, 'fa fa-download info-color': !component.downloaded}"></span>
+            <strong id="{{component.keyName}}-name">&nbsp;{{component.productName}}</strong>
+            <span id="{{component.keyName}}-version" class="product-info">| {{component.productVersion}}</span>
+            <strong id="{{component.keyName}}-download-status" class="pull-right">{{component.getDownloadStatus()}}</strong>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #952.
@dgolovin As macOS had less components when `select All`, so scrolling didn't show up the gap as mentioned in the bug. I have fixed the gap between the breadcrumb and header and verified on macOS. Can you please check if this works on Windows.
