### PR TITLE
Show the same total download size on confirmation and install page

### DIFF
--- a/browser/pages/install/controller.js
+++ b/browser/pages/install/controller.js
@@ -24,7 +24,9 @@ class InstallController {
         if(value.isDownloadRequired()) {
           this.totalDownloads += value.totalDownloads;
         }
-        this.totalAmount += value.size;
+        if(!value.downloaded) {
+          this.totalAmount += value.size;
+        }
       }
     }
     this.itemProgress = new ProgressState('', undefined, undefined, undefined, this.$scope, this.$timeout);


### PR DESCRIPTION
Current install page show total download sizw w/o counting
downloaded components