### PR TITLE
add context menu features on macOS touch bar

### DIFF
--- a/browser/bootstrap.js
+++ b/browser/bootstrap.js
@@ -47,8 +47,8 @@ function openAboutWindow() {
     show: false
   });
 
-  const about = new TouchBarButton({
-    label: 'About',
+  const documentation = new TouchBarButton({
+    label: 'Documentation',
     click: () => {
       require('electron').shell.openExternal(`https://access.redhat.com/documentation/en/red-hat-development-suite?version=${shortVersion}`);
     }
@@ -68,7 +68,14 @@ function openAboutWindow() {
     }
   });
 
-  const touchBar = new TouchBar([about, releaseNotes, issues]);
+  const closeDialogTouch = new TouchBarButton({
+    label: 'Close',
+    click: () => {
+      aboutWindow.close();
+    }
+  });
+
+  const touchBar = new TouchBar([documentation, releaseNotes, issues, new TouchBarSpacer({size: 'large'}), closeDialogTouch]);
 
   let baseLocation = encodeURI(__dirname.replace(/\\/g, '/')).replace(/#/g, '%23');
 
@@ -97,6 +104,31 @@ const help = new MenuItem({
     require('electron').shell.openExternal('https://access.redhat.com/documentation/en/red-hat-development-suite/');
   }
 });
+
+const helpTouch = new TouchBarButton({
+  label: 'Help',
+  click: () => {
+    require('electron').shell.openExternal('https://access.redhat.com/documentation/en/red-hat-development-suite/');
+  }
+});
+
+const aboutTouch = new TouchBarButton({
+  label: 'About',
+  click: openAboutWindow
+});
+
+const exitTouch = new TouchBarButton({
+  label: 'Quit',
+  click: () => {
+    require('electron').remote.getCurrentWindow().close();
+  }
+});
+
+const versionLabel  = new TouchBarLabel({
+  label: `Version: ${version}`
+})
+
+remote.getCurrentWindow().setTouchBar(new TouchBar([exitTouch, new TouchBarSpacer({size: 'large'}), helpTouch, aboutTouch, new TouchBarSpacer({size: 'small'}), versionLabel]));
 
 function restoreMenu() {
   menu = new Menu();


### PR DESCRIPTION
Fix #981 

- This gives the touch bar feature to goto `Help`, `About`. It provides the version of the application and helps the user directly quit the application.

![macos-version](https://user-images.githubusercontent.com/3133356/32127684-240c7060-bb96-11e7-9a58-7a62d5eb7837.png)

- This adds feature for _About Dialog_ to close from touch Bar on macOS.

![macos-about](https://user-images.githubusercontent.com/3133356/32127716-67107dde-bb96-11e7-9a82-3f174fe35852.png)

