### PR TITLE
Import virtualbox certificate before installation (fix #1013)

### DIFF
--- a/test/unit/model/virtualbox-test.js
+++ b/test/unit/model/virtualbox-test.js
@@ -162,6 +162,17 @@ describe('Virtualbox installer', function() {
         installer.ipcRenderer = {on: function() {}};
       });
 
+      it('should import the certificate from the executable', function() {
+        sandbox.stub(child_process, 'execFile').yields('done');
+
+        let spy = sandbox.spy(Installer.prototype, 'exec');
+        return installer.installAfterRequirements(fakeProgress, success, failure)
+        .then(() => {
+          expect(spy).to.have.been.called;
+          expect(spy).calledWith(installer.createImportCommand());
+        });
+      });
+
       it('should execute the silent extract', function() {
         sandbox.stub(child_process, 'execFile').yields('done');
 
@@ -174,13 +185,11 @@ describe('Virtualbox installer', function() {
         ];
 
         let spy = sandbox.spy(Installer.prototype, 'exec');
-        let item2 = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', installerDataSvc);
-        item2.setInstallComplete();
-        item2.thenInstall(installer);
-        installer.install(fakeProgress, success, failure);
-
-        expect(spy).to.have.been.called;
-        expect(spy).calledWith(data.join(' '));
+        return installer.installAfterRequirements(fakeProgress, success, failure)
+        .then(() => {
+          expect(spy).to.have.been.called;
+          expect(spy).calledWith(data.join(' '));
+        });
       });
 
       describe('configure', function() {


### PR DESCRIPTION
Extract the certificate from virtualbox executable and import it before installing. In case somebody does not have it yet, it should no longer prompt for "trusting oracle" when installing vbox drivers.