### PR TITLE
Fix #1017

### DIFF
--- a/browser/directives/progressBar.html
+++ b/browser/directives/progressBar.html
@@ -10,7 +10,7 @@
       ng-class="{'progress-bar-danger': progress.status.indexOf('Failed') > -1}"
       role="progressbar" aria-valuenow="{{progress.current}}" aria-valuemin="{{progress.min}}" aria-valuemax="{{progress.max}}"
       style="width: {{progress.current}}%; animation: progress-bar-stripes 2s infinite steps(15);">
-      <span>{{progress.label}}</span>
+      <span ng-hide="progress.status.indexOf('Failed') > -1">{{progress.label}}</span>
     </div>
   </div>
   <div class="progress-description">

--- a/browser/pages/selection/selection.html
+++ b/browser/pages/selection/selection.html
@@ -8,8 +8,8 @@
         <span ng-show="selectCtrl.numberOfExistingInstallations>0">&nbsp;{{selectCtrl.installedSearchNote}}&nbsp;</span>
         <span id="instructions">{{selectCtrl.installInstructions}}</span>
       </strong>
-      <span class="btn btn-default btn-action" ng-click="selectCtrl.clearAll()" ng-disabled="!selectCtrl.isAtLeastOneSelected()">Clear all</span>
-      <span class="btn btn-default btn-action" ng-click="selectCtrl.selectAll()">Select all</span>
+      <span class="btn btn-default btn-action" ng-click="selectCtrl.clearAll()" ng-disabled="!selectCtrl.isAtLeastOneSelected()" data-toggle="tooltip" data-placement="bottom" title="Clear all selected components">Clear all</span>
+      <span class="btn btn-default btn-action" ng-click="selectCtrl.selectAll()" data-toggle="tooltip" data-placement="bottom" title="Select all components available">Select all</span>
     </div>
     <form name="selectionForm" id="selectionForm" class="form-horizontal form-padding" ng-submit="selectCtrl.install()" ng-class="{'is-disabled':selectCtrl.isDisabled}">
       <div ng-repeat="item in checkboxModel">


### PR DESCRIPTION
- `remove` the progress label when download fails.

- Add `tooltip` on selection page for Select All/Clear All.