### PR TITLE
Fix #935 Add check for actual and declared size for requirements

### DIFF
--- a/test/check-requirements.js
+++ b/test/check-requirements.js
@@ -33,20 +33,6 @@ function checkRequirements() {
   fileNames['kompose'] = 'kompose';
   fileNames['fuseplatformkaraf'] = 'karaf';
 
-  //to check if the files are rougly the size they should be
-  minSizes['cdk'] = 50 * 1024;
-  minSizes['minishift-rhel'] = 300 * 1024 * 1024;
-  minSizes['oc.zip'] = 10 * 1024 * 1024;
-  minSizes['cygwin'] = 500 * 1024;
-  minSizes['devstudio'] = 400 * 1024 * 1024;
-  minSizes['jbosseap'] = 174 * 1024 * 1024;
-  minSizes['jdk'] = 50 * 1024 *1024;
-  minSizes['virtualbox'] = 85 * 1024 * 1024;
-  minSizes['7zip'] = 200 * 1024;
-  minSizes['7zip-extra'] = 400 * 1024;
-  minSizes['kompose'] = 400 * 1024;
-  minSizes['fuseplatformkaraf']= 749 *1024;
-
   console.log('-------------------------------');
   console.log('Checking download URLs');
   for (var key in data) {
@@ -69,16 +55,17 @@ function checkUrl(key) {
         req.abort();
         throw new Error(key + ' url returned code ' + response.statusCode);
       }
-      console.log(key + ' - url: ' + data[key]);
+      console.log(key + ' - url: ' + reqs[key].url);
       console.log(key + ' - size: ' + size + 'B');
-      console.log();
 
-      if (size < minSizes[key]) {
+      if (reqs[key].size!=size) {
         req.abort();
-        throw new Error(key + ' is unexpectedly small with just ' + size + ' bytes in size');
+        throw new Error(`${key} size ${size} does not match with size ${reqs[key].size} declared in requirements.json`);
       } else {
+        console.log(key + ' - size: ' + reqs[key].size + 'B in requirements.json');
         req.abort();
       }
+      console.log();
     })
     .on('end', function() {
       if (--count === 0) {


### PR DESCRIPTION
``` shell
-------------------------------
Checking download URLs
jbosseap - url: http://download-node-02.eng.bos.redhat.com/released/JBEAP-7/7.0.0/jboss-eap-7.0.0-installer.jar
jbosseap - size: 184545112B
jbosseap - size: 184545112B in requirements.json

fuseplatformkaraf - url: http://download-node-02.eng.bos.redhat.com/released/JBossFuse/6.3.0/jboss-fuse-karaf-6.3.0.redhat-187.zip
fuseplatformkaraf - size: 785784505B
fuseplatformkaraf - size: 785784505B in requirements.json

cygwin - url: https://cygwin.com/setup-x86_64.exe
cygwin - size: 907795B
cygwin - size: 907795B in requirements.json

cdk - url: http://cdk-builds.usersys.redhat.com/builds/weekly/24-Oct-2017.cdk-3.2.0/windows-amd64/minishift.exe
cdk - size: 487340032B
cdk - size: 487340032B in requirements.json

jdk - url: http://download.eng.bos.redhat.com/brewroot/packages/openjdk8-win/1.8.0.151/1.b12/win/java-1.8.0-openjdk-1.8.0.151-1.b12.redhat.windows.x86_64.msi
jdk - size: 110055424B
jdk - size: 110055424B in requirements.json

devstudio - url: https://devstudio.redhat.com/11/stable/builds/devstudio-11.1.0.GA-build-product/latest/all/devstudio-11.1.0.GA-installer-standalone.jar
devstudio - size: 678757632B
devstudio - size: 678757632B in requirements.json

7zip-extra - url: https://downloads.sourceforge.net/project/sevenzip/7-Zip/9.20/7z920_extra.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsevenzip%2Ffiles%2F7-Zip%2F9.20%2F
7zip-extra - size: 520477B
7zip-extra - size: 520477B in requirements.json

7zip - url: https://downloads.sourceforge.net/project/sevenzip/7-Zip/9.20/7za920.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsevenzip%2Ffiles%2F7-Zip%2F9.20%2F
7zip - size: 384846B
7zip - size: 384846B in requirements.json

virtualbox - url: https://developers.redhat.com/redirect/to/virtualbox-windows-5.1.24.download
virtualbox - size: 123792216B
virtualbox - size: 123792216B in requirements.json

kompose - url: https://developers.redhat.com/redirect/to/kompose-windows-1.3.0.download
kompose - size: 47578112B
kompose - size: 47578112B in requirements.json

Checking download URLs complete
```