### PR TITLE
[wip]Queue operations with progress

### DIFF
--- a/browser/model/devstudio.js
+++ b/browser/model/devstudio.js
@@ -10,7 +10,7 @@ import Logger from '../services/logger';
 import Platform from '../services/platform';
 
 class DevstudioInstall extends InstallableItem {
-  constructor(keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus, useDownload) {
+  constructor(keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus,) {
     super(keyName, downloadUrl, fileName, targetFolderName, installerDataSvc, true);
 
     this.sha256 = sha256sum;
@@ -18,7 +18,11 @@ class DevstudioInstall extends InstallableItem {
     this.addOption('install', this.version, '', true);
     this.additionalLocations = additionalLocations;
     this.additionalIus = additionalIus;
-    this.useDownload = useDownload;
+
+    if (keyName === 'fusetools') {
+      this.files = {};
+      this.useDownload = false;
+    }
   }
 
   static get KEY() {
@@ -87,8 +91,8 @@ class DevstudioInstall extends InstallableItem {
   }
 }
 
-function fromJson({keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus, useDownload}) {
-  return new DevstudioInstall(keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus, useDownload);
+function fromJson({keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus}) {
+  return new DevstudioInstall(keyName, installerDataSvc, targetFolderName, downloadUrl, fileName, sha256sum, additionalLocations, additionalIus);
 }
 
 DevstudioInstall.convertor = {fromJson};

--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -56,16 +56,41 @@ class InstallableItem {
     }
     this.downloadedFile = path.join(this.downloadFolder, fileName);
 
-    if(fs.existsSync(this.bundledFile)) {
-      this.downloaded = true;
+    if (requirement.file) {
+      this.files = requirement.file;
     } else {
-      if(fs.existsSync(this.downloadedFile)) {
-        try {
-          let stat = fs.statSync(this.downloadedFile);
-          this.downloaded = stat && (stat.size == requirement.size);
-        } catch (error) {
-          Logger.info(`${this.keyName} - fstat function failure ${error}`);
+      this.files = {};
+      this.files[this.keyName] = {
+        dmUrl: downloadUrl,
+        fileName: path.basename(fileName),
+        sha256sum: requirement.sha256sum,
+        size: this.size
+      };
+    }
+
+    this.downloaded = true;
+    this.useDownload = false;
+
+    for (let file in this.files) {
+      if (!fs.existsSync(path.join(this.bundleFolder, this.files[file].fileName))) {
+        if (fs.existsSync(path.join(this.downloadFolder, this.files[file].fileName))) {
+          try {
+            let stat = fs.statSync(path.join(this.downloadFolder, this.files[file].fileName));
+            this.downloaded = this.downloaded && (stat && (stat.size == this.files[file].size));
+            this.useDownload = !this.downloaded;
+            this.files[file].downloaded = true;
+          } catch (error) {
+            this.downloaded = false;
+            this.useDownload = true;
+            Logger.info(`${this.keyName} - fstat function failure ${error}`);
+          }
+        } else {
+          this.downloaded = false;
+          this.useDownload = true;
         }
+      } else {
+        this.files[file].downloaded = true;
+        this.downloadedFile = path.join(this.bundleFolder, this.files[file].fileName);
       }
     }
 
@@ -143,44 +168,51 @@ class InstallableItem {
 
   downloadInstaller(progress, success, failure, downloader) {
     this.downloader = downloader ? downloader : new Downloader(progress, success, failure, this.totalDownloads, this.userAgentString);
-    if(fs.existsSync(this.bundledFile)) {
-      this.downloadedFile = this.bundledFile;
-      this.downloader.closeHandler();
-    } else {
-      this.checkAndDownload(
-        this.downloadedFile,
-        this.downloadUrl,
-        this.sha256,
-        this.authRequired ? this.installerDataSvc.getUsername() : undefined,
-        this.authRequired ? this.installerDataSvc.getPassword() : undefined,
-        progress
-      );
+    for (let file in this.files) {
+      if (this.files[file].downloaded) {
+        continue;
+      }
+
+      if (fs.existsSync(path.join(this.bundleFolder, this.files[file].fileName))) {
+        this.files[file].downloadedFile = path.join(this.bundleFolder, this.files[file].fileName);
+        this.downloader.closeHandler();
+      } else {
+        this.startDownload(
+          path.join(this.downloadFolder, this.files[file].fileName),
+          this.files[file].dmUrl,
+          this.files[file].sha256sum,
+          this.authRequired ? this.installerDataSvc.getUsername() : undefined,
+          this.authRequired ? this.installerDataSvc.getPassword() : undefined,
+          progress
+        );
+      }
     }
   }
 
-  checkAndDownload(downloadedFile, url, sha, user, pass, progress) {
-    if(fs.existsSync(downloadedFile)) {
-      let h = new Hash();
-
-      if (progress.current === 0 && progress.status !== 'Downloading') {
-        progress.setStatus('Verifying previously downloaded components');
+  checkFiles() {
+    let promise = Promise.resolve();
+    for (let file in this.files) {
+      if (fs.existsSync(path.join(this.downloadFolder, this.files[file].fileName))) {
+        let h = new Hash();
+        promise = promise.then(() => {
+          return h.SHA256(path.join(this.downloadFolder, this.files[file].fileName));
+        }).then((dlSha) => {
+          if(this.files[file].sha256sum === dlSha) {
+            Logger.info(`Using previously downloaded file='${this.files[file].fileName}' sha256='${dlSha}'`);
+            this.files[file].downloaded = true;
+          } else {
+            this.useDownload = true;
+            this.downloaded = false;
+            this.files[file].downloaded = false;
+          }
+          return Promise.resolve();
+        });
       }
-
-      h.SHA256(downloadedFile, (dlSha) => {
-        if(sha === dlSha) {
-          Logger.info(`Using previously downloaded file='${downloadedFile}' sha256='${dlSha}'`);
-          this.downloader.successHandler(downloadedFile);
-        } else {
-          this.startDownload(downloadedFile, url, sha, user, pass, progress);
-        }
-      });
-    } else {
-      this.startDownload(downloadedFile, url, sha, user, pass, progress);
     }
+    return promise;
   }
 
   startDownload(downloadedFile, url, sha, user, pass, progress) {
-    progress.setStatus('Downloading');
     if(user === undefined && pass === undefined ) {
       this.downloader.download(url, downloadedFile, sha, this);
     } else {

--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -76,9 +76,9 @@ class InstallableItem {
         if (fs.existsSync(path.join(this.downloadFolder, this.files[file].fileName))) {
           try {
             let stat = fs.statSync(path.join(this.downloadFolder, this.files[file].fileName));
-            this.downloaded = this.downloaded && (stat && (stat.size == this.files[file].size));
+            this.files[file].downloaded = stat && stat.size == this.files[file].size;
+            this.downloaded = this.downloaded && this.files[file].downloaded;
             this.useDownload = !this.downloaded;
-            this.files[file].downloaded = true;
           } catch (error) {
             this.downloaded = false;
             this.useDownload = true;

--- a/browser/model/jbossfuse.js
+++ b/browser/model/jbossfuse.js
@@ -16,9 +16,13 @@ class FusePlatformInstall extends InstallableItem {
     super(FusePlatformInstall.KEY, file.platform.dmUrl, file.platform.fileName, targetFolderName, installerDataSvc, true);
     this.sha256 = file.platform.sha256sum;
     this.addOption('install', this.version, '', true);
+    this.files = file;
     this.jbeap = file.eap;
     this.jbeap.bundledFile = path.join(this.bundleFolder, this.jbeap.fileName);
     this.jbeap.downloadedFile = path.join(this.downloadFolder, this.jbeap.fileName);
+    this.platform = file.platform;
+    this.platform.bundledFile = path.join(this.bundleFolder, this.platform.fileName);
+    this.platform.downloadedFile = path.join(this.downloadFolder, this.platform.fileName);
     this.installConfigFile = path.join(this.installerDataSvc.tempDir(), 'jbosseap640-autoinstall.xml');
     this.totalDownloads = 2;
   }
@@ -26,41 +30,7 @@ class FusePlatformInstall extends InstallableItem {
   static get KEY() {
     return 'fuseplatform';
   }
-
-  downloadInstaller(progress, success, failure, downloader) {
-    this.downloader = downloader ? downloader : new Downloader(progress, success, failure, this.totalDownloads, this.userAgentString);
-    let username = this.installerDataSvc.getUsername(),
-      password = this.installerDataSvc.getPassword();
-
-    if(fs.existsSync(this.bundledFile)) {
-      this.downloadedFile = this.bundledFile;
-      this.downloader.closeHandler();
-    } else {
-      this.checkAndDownload(
-        this.downloadedFile,
-        this.downloadUrl,
-        this.sha256,
-        username,
-        password,
-        progress
-      );
-    }
-
-    if(fs.existsSync(this.jbeap.bundledFile)) {
-      this.jbeap.downloadedFile = this.jbeap.bundledFile;
-      this.downloader.closeHandler();
-    } else {
-      this.checkAndDownload(
-        this.jbeap.downloadedFile,
-        this.jbeap.dmUrl,
-        this.jbeap.sha256sum,
-        username,
-        password,
-        progress
-      );
-    }
-  }
-
+  
   installAfterRequirements(progress, success, failure) {
     progress.setStatus('Installing');
     let fusePlatformDir = this.installerDataSvc.fuseplatformDir();
@@ -103,7 +73,7 @@ class FusePlatformInstall extends InstallableItem {
   get installArgs() {
     return [
       '-jar',
-      this.downloadedFile
+      this.platform.downloadedFile
     ];
   }
 

--- a/browser/pages/confirm/controller.js
+++ b/browser/pages/confirm/controller.js
@@ -16,7 +16,11 @@ class ConfirmController {
       let totalDownloadSize = 0;
       for (let value of this.installerDataSvc.allInstallables().values()) {
         if(value.size && value.selectedOption == 'install' && !value.downloaded) {
-          totalDownloadSize += value.size;
+          for (let file in value.files) {
+            if (!value.files[file].downloaded) {
+              totalDownloadSize += value.files[file].size;
+            }
+          }
         }
       }
       return totalDownloadSize;

--- a/browser/pages/selection/controller.js
+++ b/browser/pages/selection/controller.js
@@ -66,7 +66,6 @@ class SelectionController {
     }).then(
       ()=> this.setIsDisabled()
     ).catch((error)=> {
-      console.error(error);
       this.setIsDisabled();
     });
   }

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -14,6 +14,7 @@ import child_process from'child_process';
 import Platform from '../services/platform';
 import TokenStore from './credentialManager';
 import loadMetadata from '../services/metadata';
+import Downloader from '../model/helpers/downloader';
 
 
 class InstallerDataService {
@@ -122,7 +123,6 @@ class InstallerDataService {
 
   addItemToInstall(key, item) {
     this.installableItems.set(key, item);
-    this.toInstall.add(key);
   }
 
   addItemsToInstall(...items) {
@@ -228,37 +228,71 @@ class InstallerDataService {
     return this.installing;
   }
 
-  startDownload(key) {
-    Logger.info('Download started for: ' + key);
+  verifyExistingFiles(progress, ...keys) {
+    if (keys.length < 1) {
+      this.ipcRenderer.send('checkComplete', 'all');
+      return Promise.resolve();
+    }
+    progress.setStatus('Verifying previously downloaded components');
+    progress.setTotalAmount(keys.length);
+    progress.setCurrent(1);
+
+    let promise = Promise.resolve();
+    for (let i = 0; i < keys.length; i++) {
+      promise = promise.then(() => {
+        progress.productVersion = this.getInstallable(keys[i]).productVersion;
+        progress.setProductName(this.getInstallable(keys[i]).productName);
+        return this.getInstallable(keys[i]).checkFiles();
+      }).then(() => {
+        progress.setCurrent(progress.currentAmount + 1);
+        return Promise.resolve();
+      });
+    }
+   return promise.then(() => {
+      this.ipcRenderer.send('checkComplete', 'all');
+      return Promise.resolve();
+    });
+  }
+
+  download(progress, totalDownloads, failedDownloads, userAgent, ...keys) {
+    let success = () => {
+      this.downloading = false;
+      this.ipcRenderer.send('downloadingComplete', 'all');
+    };
+
+    if (keys.length < 1) {
+      return success();
+    }
+
+    this.downloader = new Downloader(progress, success,
+      (error) => {
+        Logger.error('Download failed with: ' + error);
+        progress.setStatus('Download Failed');
+        failedDownloads.add(this.downloader);
+      },
+      totalDownloads,
+      userAgent
+    );
+    progress.setStatus('Downloading');
 
     if (!this.isDownloading()) {
       this.downloading = true;
     }
-    this.toDownload.add(key);
+
+    for (let key of keys) {
+      Logger.info('Download started for: ' + key);
+      this.getInstallable(key).downloadInstaller(
+        progress,
+        undefined,
+        undefined,
+        this.downloader
+      );
+    }
   }
 
-  downloadDone(progress, key) {
-    Logger.info('Download finished for: ' + key);
-
-    let item = this.getInstallable(key);
-    item.setDownloadComplete();
-
-    this.toDownload.delete(key);
-    if (this.isDownloading() && this.toDownload.size == 0) {
-      this.downloading = false;
-      this.ipcRenderer.send('downloadingComplete', 'all');
-    }
-
-    this.startInstall(key);
-
-    return item.install(progress,
-      () => {
-        this.installDone(progress, key);
-      },
-      (error) => {
-        Logger.error(key + ' failed to install: ' + error);
-      }
-    );
+  restartDownload() {
+    Logger.info('Restarting download');
+    this.downloader.restartDownload();
   }
 
   startInstall(key) {
@@ -298,7 +332,6 @@ class InstallerDataService {
       Logger.info('All installs complete');
       this.installing = false;
       this.ipcRenderer.send('installComplete', 'all');
-      // this.router.go('start');
     }
   }
 

--- a/requirements.json
+++ b/requirements.json
@@ -114,7 +114,7 @@
         "version": "3.2.0-GA",
         "size": 487191808,
         "installSize" : 836390912,
-        "requires": ["kvm"],
+        "requires": ["virtualbox"],
         "installAfter": "virtualbox"
       }
     }

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -154,12 +154,6 @@ describe('CDK installer', function() {
       authStub = sandbox.stub(Downloader.prototype, 'downloadAuth').returns();
     });
 
-    it('should set progress to "Downloading"', function() {
-      installer.downloadInstaller(fakeProgress, success, failure);
-
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
     it('should write the data into temp folder', function() {
 
       installer.downloadInstaller(fakeProgress, success, failure);

--- a/test/unit/model/cygwin-test.js
+++ b/test/unit/model/cygwin-test.js
@@ -102,13 +102,6 @@ describe('Cygwin installer', function() {
       downloadStub = sandbox.stub(Downloader.prototype, 'download').returns();
     });
 
-    it('should set progress to "Downloading"', function() {
-      installer.downloadInstaller(fakeProgress, success, failure);
-
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
     it('should write the data into temp/cygwin.exe', function() {
       installer.downloadInstaller(fakeProgress, success, failure);
 

--- a/test/unit/model/devstudio-test.js
+++ b/test/unit/model/devstudio-test.js
@@ -112,13 +112,6 @@ describe('devstudio installer', function() {
       downloadAuthStub = sandbox.stub(Downloader.prototype, 'downloadAuth').returns();
     });
 
-    it('should set progress to "Downloading"', function() {
-      installer.downloadInstaller(fakeProgress, success, failure);
-
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
     it('should write the data into temp/devstudio.jar', function() {
       installer.downloadInstaller(fakeProgress, success, failure);
 

--- a/test/unit/model/helpers/downloader-test.js
+++ b/test/unit/model/helpers/downloader-test.js
@@ -95,60 +95,60 @@ describe('Downloader', function() {
   });
 
   it('closeHandler should verify downloaded files checksum', function() {
-    let stub = sandbox.stub(Hash.prototype, 'SHA256').yields('hash');
+    let stub = sandbox.stub(Hash.prototype, 'SHA256').resolves('hash');
 
     downloader.downloads.set('file', {options: 'options', sha: 'hash', 'failure': false});
-    downloader.closeHandler('file', 'hash', 'url');
-
-    expect(stub).to.have.been.calledOnce;
-    expect(stub).to.have.been.calledWith('file');
+    return downloader.closeHandler('file', 'hash').then(() => {
+      expect(stub).to.have.been.calledOnce;
+      expect(stub).to.have.been.calledWith('file');
+    });
   });
 
   it('closeHandler should set progress status to "Verifying Download" during SHA check if download is done', function () {
-    sandbox.stub(Hash.prototype, 'SHA256').yields('hash');
+    sandbox.stub(Hash.prototype, 'SHA256').resolves('hash');
     fakeProgress.current = 100;
 
     downloader.downloads.set('file', {options: 'options', sha: 'hash', 'failure': false});
-    downloader.closeHandler('file', 'hash', 'url');
-
-    expect(fakeProgress.setStatus).to.have.been.calledOnce;
-    expect(fakeProgress.setStatus).to.have.been.calledWith('Verifying Download');
+    return downloader.closeHandler('file', 'hash').then(() => {
+      expect(fakeProgress.setStatus).to.have.been.calledOnce;
+      expect(fakeProgress.setStatus).to.have.been.calledWith('Verifying Download');
+    });
   });
 
   it('closeHandler should not set progress status to "Verifying Download" during SHA check if download is not done', function () {
-    sandbox.stub(Hash.prototype, 'SHA256').yields('hash');
-    fakeProgress.current = 88;
-
+    sandbox.stub(Hash.prototype, 'SHA256').resolves('hash');
     downloader.downloads.set('file', {options: 'options', sha: 'hash', 'failure': false});
-    downloader.closeHandler('file', 'hash', 'url');
+    downloader.downloads.set('file2', {options: 'options', sha: 'hash', 'failure': false});
 
-    expect(fakeProgress.setStatus).to.have.not.been.called;
+    return downloader.closeHandler('file', 'hash').then(() => {
+      expect(fakeProgress.setStatus).to.have.not.been.called;
+    });
   });
 
   it('closeHandler should call success when verification succeeds', function() {
     downloader = new Downloader(fakeProgress, succ, fail);
-    sandbox.stub(Hash.prototype, 'SHA256').yields('hash');
+    sandbox.stub(Hash.prototype, 'SHA256').resolves('hash');
     let successSpy = sandbox.spy(downloader, 'success');
     let failureSpy = sandbox.spy(downloader, 'failure');
 
     downloader.downloads.set('file', {options: 'options', sha: 'hash', 'failure': false});
-    downloader.closeHandler('file', 'hash');
-
-    expect(successSpy).to.have.been.calledOnce;
-    expect(failureSpy).to.have.not.been.called;
+    downloader.closeHandler('file', 'hash').then(() => {
+      expect(successSpy).to.have.been.calledOnce;
+      expect(failureSpy).to.have.not.been.called;
+    });
   });
 
   it('closeHandler should call failure when verification fails', function() {
     downloader = new Downloader(fakeProgress, succ, fail);
     downloader.downloads.set('file', {options: 'options', sha: 'sha', 'failure': false});
-    sandbox.stub(Hash.prototype, 'SHA256').yields('hash');
+    sandbox.stub(Hash.prototype, 'SHA256').resolves('hash');
     let successSpy = sandbox.spy(downloader, 'success');
     let failureSpy = sandbox.spy(downloader, 'failure');
 
-    downloader.closeHandler('file', 'hash1');
-
-    expect(failureSpy).to.have.been.calledOnce;
-    expect(successSpy).to.have.not.been.called;
+    downloader.closeHandler('file', 'hash1').then(() => {
+      expect(failureSpy).to.have.been.calledOnce;
+      expect(successSpy).to.have.not.been.called;
+    });
   });
 
   describe('download', function() {

--- a/test/unit/model/installable-item-test.js
+++ b/test/unit/model/installable-item-test.js
@@ -102,7 +102,6 @@ describe('InstallableItem', function() {
   });
 
   describe('getInstallAfter method', function() {
-
     it('should ignore skipped installers and return first selected for installation', function() {
       let svc = new InstallerDataService();
       let item1 = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', svc);
@@ -115,7 +114,6 @@ describe('InstallableItem', function() {
       item1.thenInstall(item2).thenInstall(item3).thenInstall(item4);
       expect(item4.getInstallAfter()).to.be.equal(item1);
     });
-
   });
 
   describe('getProductVersion', function() {
@@ -125,76 +123,39 @@ describe('InstallableItem', function() {
       item.selectedOption = 'detected';
       expect(item.getProductVersion()).to.be.equal('1.2');
     });
+
     it('returns version for included product if not detected', function() {
       let item = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', new InstallerDataService());
       expect(item.getProductVersion()).to.be.equal(item.version);
     });
   });
 
-  describe('checkAndDownload method', function() {
-    let svc, downloader, installItem;
+  describe('checkFiles method', function() {
+    it('should check each downloaded file', function() {
 
-    beforeEach(function() {
-      svc = new InstallerDataService();
-      downloader = new Downloader(null, function() {});
-      installItem = new InstallableItem('jdk', 'downloadUrl', 'fileName', 'targetLocation', svc, false);
-      installItem.downloader = downloader;
     });
 
-    it('should start to download file if there is no dowloaded file', function() {
-      sandbox.stub(fs, 'existsSync').returns(false);
-      let startDlMock = sandbox.stub(installItem, 'startDownload').returns();
+    it('should confirm file is downloaded when checksums match', function() {
 
-      installItem.checkAndDownload('temp/inatall.zip', 'url', 'sha', undefined, undefined, fakeProgress);
-
-      expect(startDlMock).to.have.been.calledOnce;
     });
 
-    it('should start download file if there is dowloaded file with wrong checksum', function() {
-      sandbox.stub(fs, 'existsSync').returns(true);
-      let startDlMock = sandbox.stub(installItem, 'startDownload').returns();
-      sandbox.stub(Hash.prototype, 'SHA256').yields('wrongsha');
+    it('should set the component to download when a checksum does not match', function() {
 
-      installItem.checkAndDownload('temp/inatall.zip', 'url', 'sha', undefined, undefined, fakeProgress);
-
-      expect(startDlMock).to.have.been.calledOnce;
     });
 
-    it('should not start download file if there is dowloaded file with correct checksum', function() {
-      let successHandStub = sandbox.stub(downloader, 'successHandler').returns();
-      sandbox.stub(fs, 'existsSync').returns(true);
-      sandbox.stub(installItem, 'startDownload').returns();
-      sandbox.stub(Hash.prototype, 'SHA256').yields('sha');
+    it('should skip files that do not exist', function() {
 
-      installItem.checkAndDownload('temp/inatall.zip', 'url', 'sha', undefined, undefined, fakeProgress);
+    });
+  });
 
-      expect(successHandStub).to.have.been.calledOnce;
+  describe('downloadInstaller method', function() {
+    it('should start download for each file not downloaded', function() {
+
     });
 
-    it('should set progress status to "Verifying Existing Download" if a downloaded file exists', function() {
-      sandbox.stub(downloader, 'successHandler').returns();
-      sandbox.stub(fs, 'existsSync').returns(true);
-      sandbox.stub(installItem, 'startDownload').returns();
-      sandbox.stub(Hash.prototype, 'SHA256').yields('sha');
+    it('should skip downloaded and bundled files', function() {
 
-      installItem.checkAndDownload('temp/inatall.zip', 'url', 'sha', undefined, undefined, fakeProgress);
-
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Verifying previously downloaded components');
     });
-
-    it('should not change progress status if current status is \'Downloading\'', function() {
-      sandbox.stub(downloader, 'successHandler').returns();
-      sandbox.stub(fs, 'existsSync').returns(true);
-      sandbox.stub(installItem, 'startDownload').returns();
-      sandbox.stub(Hash.prototype, 'SHA256').yields('sha');
-      fakeProgress = sandbox.stub(new ProgressState());
-      fakeProgress.status = 'Downloading';
-      installItem.checkAndDownload('temp/inatall.zip', 'url', 'sha', undefined, undefined, fakeProgress);
-
-      expect(fakeProgress.setStatus).have.not.been.called;
-    });
-
   });
 
   describe('startDownload method', function() {
@@ -222,15 +183,6 @@ describe('InstallableItem', function() {
 
       downloadStub.verify();
     });
-
-    it('should set the progress state to "Downloading"', function() {
-      sinon.mock(installItem.downloader).expects('downloadAuth').once().withArgs('url', 'user', 'password', 'downloadto.zip', 'sha');
-      installItem.startDownload('downloadto.zip', 'url', 'sha', 'user', 'password', fakeProgress);
-
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
   });
 
   describe('when instantiated', function() {
@@ -260,31 +212,37 @@ describe('InstallableItem', function() {
       let svc = new InstallerDataService();
       item = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', svc);
     });
+
     describe('should return true', function() {
       it('when item is not detected and selected for installation', function() {
         item.setSelectedOption = 'install';
         expect(item.isConfigured()).to.be.true;
       });
+
       it('when item is detected, valid and selected for installation', function() {
         item.setSelectedOption = 'install';
         item.addOption('detected', '1.0.0', 'path/to/location', true);
         expect(item.isConfigured()).to.be.true;
       });
+
       it('when item is detected, invalid and selected for installation', function() {
         item.setSelectedOption = 'install';
         item.addOption('detected', '1.0.0', 'path/to/location', false);
         expect(item.isConfigured()).to.be.true;
       });
+
       it('when item is detected, valid and is not selected for installation', function() {
         item.setSelectedOption = 'detected';
         item.addOption('detected', '1.0.0', 'path/to/location', true);
         expect(item.isConfigured()).to.be.true;
       });
+
       it('when item is not detected and is not selected for installation', function() {
         item.setSelectedOption = 'detected';
         expect(item.isConfigured()).to.be.true;
       });
     });
+
     describe('should return false', function() {
       it('when item is detected, invalid and is not selected for installation', function() {
         item.selectedOption = 'detected';
@@ -357,6 +315,7 @@ describe('InstallableItem', function() {
       let svc = new InstallerDataService();
       item = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', svc);
     });
+
     describe('should return true', function() {
       it('if item detectded and invalid', function() {
         item.selectedOption = 'detected';
@@ -364,11 +323,13 @@ describe('InstallableItem', function() {
         expect(item.isInvalidVersionDetected()).to.be.true;
       });
     });
+
     describe('should return false', function() {
       it('if not detectded', function() {
         item.selectedOption = 'detected';
         expect(item.isInvalidVersionDetected()).to.be.false;
       });
+
       it('if item detectded and valid', function() {
         item.selectedOption = 'detected';
         item.addOption('detected', '1.0.0', 'path/to/location', true);
@@ -382,12 +343,14 @@ describe('InstallableItem', function() {
       let svc = new InstallerDataService();
       item = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', svc);
     });
+
     it('should return location for detected option if detected', function() {
       item.selectedOption = 'detected';
       item.addOption('detected', '1.0.0', 'path/to/detected/location', true);
       item.addOption('install', '1.0.0', 'path/to/instal/location', true);
       expect(item.getLocation()).to.be.equal('path/to/detected/location');
     });
+
     it('should return location for install option if not detected', function() {
       item.selectedOption = 'detected';
       item.addOption('install', '1.0.0', 'path/to/instal/location', true);
@@ -420,6 +383,7 @@ describe('InstallableItem', function() {
       item.references = 1;
       expect(item.isDisabled()).to.be.equal(true);
     });
+
     it('returns false if there are no references', function() {
       item.references = 0;
       expect(item.isDisabled()).to.be.equal(false);
@@ -432,14 +396,17 @@ describe('InstallableItem', function() {
       item.size = 100;
       expect(item.getDownloadStatus()).equals('Selected to download');
     });
+
     it('returns \'No download required\' if item download size is undefined', function() {
       delete item.size;
       expect(item.getDownloadStatus()).equals('No download required');
     });
+
     it('returns \'No download required\' if item download size equals 0', function() {
       item.size = 0;
       expect(item.getDownloadStatus()).equals('No download required');
     });
+
     it('returns \'Previously Downloaded\' if item is downloaded and size is more than 0', function() {
       item.downloaded = true;
       item.size = 100;

--- a/test/unit/model/jbosseap-test.js
+++ b/test/unit/model/jbosseap-test.js
@@ -136,13 +136,6 @@ describe('jbosseap installer', function() {
       downloadAuthStub = sandbox.stub(Downloader.prototype, 'downloadAuth').returns();
     });
 
-    it('should set progress to "Downloading"', function() {
-      installer.downloadInstaller(fakeProgress, success, failure);
-
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
     it('should write the data into temp/jbosseap.jar', function() {
 
       installer.downloadInstaller(fakeProgress, success, failure);

--- a/test/unit/model/jbossfuse-test.js
+++ b/test/unit/model/jbossfuse-test.js
@@ -125,13 +125,6 @@ describe('fuseplatform installer', function() {
       downloadAuthStub = sandbox.stub(Downloader.prototype, 'downloadAuth').returns();
     });
 
-    it('should set progress to "Downloading"', function() {
-      installer.downloadInstaller(fakeProgress, success, failure);
-
-      expect(fakeProgress.setStatus).to.have.been.calledTwice;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
     it('should write the data into temp/fuseplatform.jar', function() {
       installer.downloadInstaller(fakeProgress, success, failure);
 

--- a/test/unit/model/jbossfusekaraf-test.js
+++ b/test/unit/model/jbossfusekaraf-test.js
@@ -93,6 +93,7 @@ describe('jbossplaformkaraf nstaller', function() {
         );
       });
     });
+    
     it('should remove first level folder when unpack files from zip archive', function() {
       let mockDevSuiteInstaller = createInstallerMock(false);
       let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
@@ -103,6 +104,7 @@ describe('jbossplaformkaraf nstaller', function() {
         );
       });
     });
+
     it('should configure runtime detection after devstudio installation finished', function() {
       let mockDevSuiteInstaller = createInstallerMock(false);
       let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);
@@ -117,6 +119,7 @@ describe('jbossplaformkaraf nstaller', function() {
         expect(devstudioInstaller.configureRuntimeDetection).calledOnce;
       });
     });
+
     it('should return rejected promice if exception cought during unpacking', function() {
       let mockDevSuiteInstaller = createInstallerMock(false);
       mkdirp.sync.restore();
@@ -129,6 +132,7 @@ describe('jbossplaformkaraf nstaller', function() {
         expect(error.name).equals('Error');
       });
     });
+
     it('should return rejected promise if unzip-stream emitted error', function() {
       let mockDevSuiteInstaller = createInstallerMock(false);
       let promise = fuseInstaller.installAfterRequirements(fakeProgress, success, failure);

--- a/test/unit/model/jdk-install-test.js
+++ b/test/unit/model/jdk-install-test.js
@@ -311,14 +311,6 @@ describe('JDK installer', function() {
       downloadStub = sandbox.stub(Downloader.prototype, 'downloadAuth').returns();
     });
 
-    it('should set progress to "Downloading"', function() {
-      sandbox.stub(fs, 'existsSync').returns(false);
-      installer.downloadInstaller(fakeProgress, success, failure);
-
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
     it('should write the data into temp/jdk.msi', function() {
 
       installer.downloadInstaller(fakeProgress, success, failure);

--- a/test/unit/model/kompose-test.js
+++ b/test/unit/model/kompose-test.js
@@ -95,11 +95,6 @@ describe('kompose installer', function() {
       authStub = sandbox.stub(Downloader.prototype, 'download').returns();
     });
 
-    it('should set progress to "Downloading"', function() {
-      installer.downloadInstaller(fakeProgress, success, failure);
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
     it('should write the data into temp folder', function() {
       installer.downloadInstaller(fakeProgress, success, failure);
       expect(authStub.callCount).to.equal(1);

--- a/test/unit/model/virtualbox-test.js
+++ b/test/unit/model/virtualbox-test.js
@@ -100,13 +100,6 @@ describe('Virtualbox installer', function() {
       downloadStub = sandbox.stub(Downloader.prototype, 'download').returns();
     });
 
-    it('should set progress to "Downloading"', function() {
-      installer.downloadInstaller(fakeProgress, success, failure);
-
-      expect(fakeProgress.setStatus).to.have.been.calledOnce;
-      expect(fakeProgress.setStatus).to.have.been.calledWith('Downloading');
-    });
-
     it('should write the data into temp/virtualbox.exe', function() {
 
       installer.downloadInstaller(fakeProgress, success, failure);

--- a/test/unit/services/data-test.js
+++ b/test/unit/services/data-test.js
@@ -46,7 +46,10 @@ describe('InstallerDataService', function() {
 
   let fakeProgress = {
     installTrigger: function() {},
-    setStatus: function() {}
+    setStatus: function() {},
+    setTotalAmount: function() {},
+    setProductName: function() {},
+    setCurrent: function() {}
   };
 
   describe('initial state', function() {
@@ -223,72 +226,101 @@ describe('InstallerDataService', function() {
 
   });
 
-  describe('downloading', function() {
+  describe('verifyExistingFiles', function() {
+    let checkStub;
+
     beforeEach(function() {
       svc.addItemToInstall('jdk', jdk);
       svc.addItemToInstall('vbox', vbox);
 
-      sandbox.stub(jdk, 'downloadInstaller').returns();
-      sandbox.stub(vbox, 'downloadInstaller').returns();
+      checkStub = sandbox.stub(InstallableItem.prototype, 'checkFiles').resolves();
     });
 
-    it('startDownload should queue the installable for download', function() {
-      svc.startDownload('jdk');
-      expect(svc.isDownloading()).to.be.true;
-      expect(svc.toDownload.size).to.equal(1);
-      expect(svc.toDownload.has('jdk')).to.be.true;
+    it('should call checkFiles for each component passed', function() {
+      return svc.verifyExistingFiles(fakeProgress, 'jdk', 'vbox').then(() => {
+        expect(checkStub).calledTwice;
+        expect(checkStub).calledOn(jdk);
+        expect(checkStub).calledOn(vbox);
+      });
     });
 
-    it('downloadDone should signal that the download has finished', function() {
-      svc.startDownload('jdk');
-      svc.startDownload('vbox');
-      sandbox.stub(jdk, 'install');
+    it('should set status to "Verifying previously downloaded components"', function() {
+      let spy = sandbox.spy(fakeProgress, 'setStatus');
+      svc.verifyExistingFiles(fakeProgress, 'jdk', 'vbox');
 
-      svc.downloadDone(fakeProgress, 'jdk');
-
-      expect(jdk.isDownloaded()).to.be.true;
-      expect(svc.toDownload.size).to.equal(1);
+      expect(spy).calledWith('Verifying previously downloaded components');
     });
 
-    it('downloadDone should trigger install on the installable', function() {
-      svc.startDownload('jdk');
-      svc.startDownload('vbox');
+    it('should set total amount to number of components passed', function() {
+      let spy = sandbox.spy(fakeProgress, 'setTotalAmount');
+      svc.verifyExistingFiles(fakeProgress, 'jdk', 'vbox');
 
-      let spy = sandbox.spy(svc, 'startInstall');
-      let stub = sandbox.stub(jdk, 'install').returns();
-
-      svc.downloadDone(fakeProgress, 'jdk');
-
-      expect(spy).calledWith('jdk');
-      expect(stub).calledOnce;
+      expect(spy).calledWith(2);
     });
 
-    it('downloadDone should call installDone when installation is finished', function() {
-      svc.addItemsToInstall(jdk);
-      sandbox.stub(jdk, 'install').yields();
-      sandbox.stub(svc, 'installDone');
-      svc.downloadDone(undefined, jdk.keyName);
-      expect(svc.installDone).to.be.calledOnce;
+    it('should set product info to currently processed component', function() {
+      let spy = sandbox.spy(fakeProgress, 'setProductName');
+      return svc.verifyExistingFiles(fakeProgress, 'jdk', 'vbox').then(() => {
+        expect(spy).calledTwice;
+        expect(spy).calledWith(jdk.productName);
+        expect(spy).calledWith(vbox.productName);
+      });
     });
 
-    it('downloadDone should log error when installation is failed', function() {
-      svc.addItemsToInstall(jdk);
-      sandbox.stub(jdk, 'install').callsArgWith(2, 'error');
-      Logger.error.reset();
-      svc.downloadDone(undefined, jdk.keyName);
-      expect(Logger.error).to.be.calledOnce;
+    it('should increment current amount for each completed component', function() {
+      let spy = sandbox.spy(fakeProgress, 'setCurrent');
+      return svc.verifyExistingFiles(fakeProgress, 'jdk', 'vbox').then(() => {
+        expect(spy).calledThrice;
+      });
     });
 
-    it('downloadDone should send an event when all downloads have finished', function() {
-      svc.startDownload('jdk');
-      svc.startDownload('vbox');
-
-      sandbox.stub(jdk, 'install').returns();
-      sandbox.stub(vbox, 'install').returns();
+    it('should skip checks when no components were passed', function() {
       let spy = sandbox.spy(svc.ipcRenderer, 'send');
+      return svc.verifyExistingFiles(fakeProgress).then(() => {
+        expect(checkStub).not.called;
+        expect(spy).calledOnce;
+        expect(spy).calledWith('checkComplete', 'all');
+      });
+    });
 
-      svc.downloadDone(fakeProgress, 'jdk');
-      svc.downloadDone(fakeProgress, 'vbox');
+    it('should fire "checkComplete" event when complete', function() {
+      let spy = sandbox.spy(svc.ipcRenderer, 'send');
+      return svc.verifyExistingFiles(fakeProgress, 'jdk', 'vbox').then(() => {
+        expect(spy).calledOnce;
+        expect(spy).calledWith('checkComplete', 'all');
+      });
+    });
+  });
+
+  describe('download', function() {
+    let dlStub;
+
+    beforeEach(function() {
+      svc.addItemToInstall('jdk', jdk);
+      svc.addItemToInstall('vbox', vbox);
+
+      dlStub = sandbox.stub(InstallableItem.prototype, 'downloadInstaller').returns();
+    });
+
+    it('should set status to "Downloading"', function() {
+      let spy = sandbox.spy(fakeProgress, 'setStatus');
+      svc.download(fakeProgress, 2, new Set(), '', 'vbox', 'jdk');
+
+      expect(spy).calledOnce;
+      expect(spy).calledWith('Downloading');
+    });
+
+    it('should call downloadInstaller for each component', function() {
+      svc.download(fakeProgress, 2, new Set(), '', 'vbox', 'jdk');
+
+      expect(dlStub).calledTwice;
+      expect(dlStub).calledOn(jdk);
+      expect(dlStub).calledOn(vbox);
+    });
+
+    it('should fire a "downloadingComplete" event when all downloads finish', function() {
+      let spy = sandbox.spy(svc.ipcRenderer, 'send');
+      svc.download(fakeProgress, 2, new Set(), '');
 
       expect(spy).calledOnce;
       expect(spy).calledWith('downloadingComplete', 'all');


### PR DESCRIPTION
This turned out way bigger than originally intended (to fix #1012). On the upside, it now fixes #995 as well.
Changelog:
 - split checkAndDownload into check and download (if check is successful, download is not even called)
 - made all checks done per file for each component
 - InstallerDataService takes care of delegating to each component, the install controller now mostly just uses that
 - the flow is now 'verify existing => download (and check) => install' using events to advance to next step
 - all steps now use the progress bar
 - post download checks are now queued asynchronously to the download, and if some remain after download is done, they take over the progress bar

Take it for a spin please, and once again sorry for how big it turned out to be - it just didn't seem to work in smaller pieces.