### PR TITLE
Remove not required Promise.resolve() throughout the code

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -52,7 +52,7 @@ class CDKInstall extends InstallableItem {
     }).then(()=> {
       return installer.exec(
         'minishift stop', {env: this.createEnvironment()}
-      ).catch(()=>Promise.resolve());
+      ).catch(()=>{});
     }).then(()=> {
       return installer.exec(`minishift setup-cdk --force --default-vm-driver=${driverName}`, {env:this.createEnvironment()});
     }).then(()=> {
@@ -62,7 +62,6 @@ class CDKInstall extends InstallableItem {
       return globby(ocExePattern, {root: path.join(home, 'cache', 'oc')});
     }).then((files)=> {
       ocExe = files[0].replace(/\//g, path.sep);
-      return Promise.resolve();
     }).then(()=> {
       return Platform.makeFileExecutable(ocExe);
     }).then(()=> {

--- a/browser/model/cygwin.js
+++ b/browser/model/cygwin.js
@@ -45,7 +45,6 @@ class CygwinInstall extends InstallableItem {
         if(this.option.detected) {
           delete this.option.detected;
         }
-        return Promise.resolve();
       });
     } else {
       return Promise.resolve();

--- a/browser/model/helpers/downloader.js
+++ b/browser/model/helpers/downloader.js
@@ -91,7 +91,6 @@ class Downloader {
             this.failure('SHA256 checksum verification failed');
           }
           this.checkAmount--;
-          return Promise.resolve();
         });
       });
     } else {

--- a/browser/model/hyperv.js
+++ b/browser/model/hyperv.js
@@ -22,12 +22,11 @@ class HypervInstall extends InstallableItem {
         this.hypervstatus = detected;
         this.hidden = this.hypervstatus === undefined;
         this.selectedOption = 'detected';
-        return Promise.resolve(detected);
+        return detected;
       }).then((detected)=> {
         if (detected) {
           return Platform.getHypervisorVersion();
         }
-        return Promise.resolve();
       }).then((version)=>{
         if(version) {
           this.option.detected.version = version;

--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -205,7 +205,6 @@ class InstallableItem {
             this.downloaded = false;
             this.files[file].downloaded = false;
           }
-          return Promise.resolve();
         });
       }
     }

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -43,7 +43,7 @@ class JdkInstall extends InstallableItem {
       } else if(Platform.OS == 'darwin') {
         return this.findDarwinJava();
       } else {
-        return Promise.resolve('');
+        return '';
       }
     }).then((output)=>{
       this.openJdkMsi = output.length>0;
@@ -81,7 +81,6 @@ class JdkInstall extends InstallableItem {
       if(this.option.detected) {
         delete this.option.detected;
       }
-      return Promise.resolve();
     });
   }
 
@@ -123,7 +122,7 @@ class JdkInstall extends InstallableItem {
         if (!output || output.startsWith('Unable to find any JVMs')) {
           return Promise.reject('No java detected');
         } else {
-          return Promise.resolve(output);
+          return output;
         }
       });
   }

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -79,10 +79,9 @@ class VirtualBoxInstallWindows extends VirtualBoxInstall {
       if(output === '%VBOX_MSI_INSTALL_PATH%') {
         return Util.executeCommand('where VirtualBox', 1);
       }
-      return Promise.resolve(output);
+      return output;
     }).then((output) => {
-      tempDetectedLocation = output;
-      return Promise.resolve(output);
+      return tempDetectedLocation = output;
     }).then((output) => {
       return Util.folderContains(output, ['VirtualBox.exe', 'VBoxManage.exe']);
     }).then((output) => {
@@ -98,12 +97,10 @@ class VirtualBoxInstallWindows extends VirtualBoxInstall {
         delete this.option.detected;
       }
       this.addOption('install', this.version, path.join(this.installerDataSvc.installRoot, 'virtualbox'), true);
-      return Promise.resolve();
     }).then(()=>{
       return Platform.isVirtualizationEnabled();
     }).then((result)=>{
       this.virtualizationEnabled=result;
-      return Promise.resolve();
     });
   }
 
@@ -226,7 +223,6 @@ class VirtualBoxInstallDarwin extends VirtualBoxInstall {
         delete this.option.detected;
       }
       this.addOption('install', this.version, '/usr/local/bin', true);
-      return Promise.resolve();
     }).then(() => {
       return Platform.isVirtualizationEnabled();
     }).then((result) => {

--- a/browser/pages/selection/controller.js
+++ b/browser/pages/selection/controller.js
@@ -62,7 +62,6 @@ class SelectionController {
     return this.detectInstalledComponents().then(()=> {
       this.graph = ComponentLoader.loadGraph(this.installerDataSvc);
       this.installWatchers();
-      return Promise.resolve();
     }).then(
       ()=> this.setIsDisabled()
     ).catch((error)=> {

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -239,15 +239,15 @@ class InstallerDataService {
   }
 
   verifyExistingFiles(progress, ...keys) {
+    let promise = Promise.resolve();
     if (keys.length < 1) {
       this.ipcRenderer.send('checkComplete', 'all');
-      return Promise.resolve();
+      return promise;
     }
     progress.setStatus('Verifying previously downloaded components');
     progress.setTotalAmount(keys.length);
     progress.setCurrent(1);
 
-    let promise = Promise.resolve();
     for (let i = 0; i < keys.length; i++) {
       promise = promise.then(() => {
         progress.productVersion = this.getInstallable(keys[i]).productVersion;
@@ -255,12 +255,10 @@ class InstallerDataService {
         return this.getInstallable(keys[i]).checkFiles();
       }).then(() => {
         progress.setCurrent(progress.currentAmount + 1);
-        return Promise.resolve();
       });
     }
    return promise.then(() => {
       this.ipcRenderer.send('checkComplete', 'all');
-      return Promise.resolve();
     });
   }
 

--- a/browser/services/openpgp.js
+++ b/browser/services/openpgp.js
@@ -20,7 +20,7 @@ function loadSignedText(keyText, armoredText) {
       return {options, verified};
     });
   }).catch((error)=>{
-    return Promise.resolve({
+    return {
       options: {
         message: {
           text: armoredText
@@ -32,7 +32,7 @@ function loadSignedText(keyText, armoredText) {
         }]
       },
       error
-    });
+    };
   }).then(function({options, verified, error}) {
     return {
       text: options.message.text,

--- a/browser/services/platform.js
+++ b/browser/services/platform.js
@@ -64,34 +64,27 @@ class Platform {
     return Platform.identify({
       win32: function() {
         return pify(child_process.exec)('powershell.exe -command "(GWMI Win32_Processor).VirtualizationFirmwareEnabled;[Environment]::Exit(0);"').then((stdout)=>{
-          let result = Promise.resolve();
+          let result;
           if(stdout) {
             stdout = stdout.replace(/\s/g, '');
             if(stdout == 'True') {
-              result = Promise.resolve(true);
+              result = true;
             } else if(stdout == 'False') {
-              result = Promise.resolve(false);
+              result = false;
             }
           }
           return result;
         }).catch(()=>{
-          return Promise.resolve();
+          // Ignore errors
         });
       },
       darwin: function() {
         return pify(child_process.exec)('sysctl -a | grep -o VMX').then((stdout)=>{
-          let result = Promise.resolve();
           if(stdout) {
-            stdout = stdout.replace(/\s/g, '');
-            if(stdout == 'VMX') {
-              result = Promise.resolve(true);
-            } else {
-              result = Promise.resolve(false);
-            }
+            return stdout.replace(/\s/g, '') == 'VMX';
           }
-          return result;
         }).catch(()=>{
-          return Promise.resolve();
+          // ignore errors
         });
       },
       default: function() {
@@ -104,16 +97,16 @@ class Platform {
     return Platform.identify({
       win32: function() {
         return pify(child_process.exec)('powershell -ExecutionPolicy ByPass -command "(get-item c:\\windows\\system32\\vmms.exe).VersionInfo.ProductVersion"').then((stdout) => {
-          let result = Promise.resolve('Unknown');
+          let result = 'Unknown';
           if(stdout) {
             stdout = stdout.replace(/\s/g, '');
             if(stdout) {
-              result = Promise.resolve(stdout);
+              result = stdout;
             }
           }
           return result;
         }).catch(()=>{
-          return Promise.resolve('Unknown');
+          return 'Unknown';
         });
       },
       default: function() {
@@ -126,18 +119,17 @@ class Platform {
     return Platform.identify({
       win32: function() {
         return pify(child_process.exec)('PowerShell.exe -ExecutionPolicy Bypass -command "Get-WindowsOptionalFeature -Online | where FeatureName -eq Microsoft-Hyper-V-Hypervisor | foreach{$_.state}; [Environment]::Exit(0);"').then((stdout) => {
-          let result = Promise.resolve();
+          let result;
           if(stdout) {
             stdout = stdout.replace(/\s/g, '');
             if(stdout == 'Enabled') {
-              result = Promise.resolve(true);
+              result = true;
             } else if(stdout == 'Disabled') {
-              result = Promise.resolve(false);
+              result = false;
             }
           }
           return result;
         }).catch(()=>{
-          return Promise.resolve();
         });
       },
       default: function() {
@@ -162,9 +154,8 @@ class Platform {
       win32: ()=> {
         let disk = path.parse(location).root.charAt(0);
         return pify(child_process.exec)(`powershell -command "& {(Get-WMIObject Win32_Logicaldisk -filter deviceid='''${disk}:''').FreeSpace;[Environment]::Exit(0);}"`).then((stdout) => {
-          return Promise.resolve(Number.parseInt(stdout));
+          return Number.parseInt(stdout);
         }).catch(()=>{
-          return Promise.resolve();
         });
       },
       darwin: ()=> {
@@ -172,9 +163,9 @@ class Platform {
         return pify(child_process.exec)(`df -k ${path}`).then((stdout) => {
           let lines = stdout.split('\n');
           let split = lines[1].replace( / +/g, ' ' ).split(' ');
-          return Promise.resolve(Number.parseInt(split[split.length - 1] === '/' ? split[3] : split[4]));
+          return Number.parseInt(split[split.length - 1] === '/' ? split[3] : split[4]);
         }).catch(()=>{
-          return Promise.resolve('No such file or dir');
+          return 'No such file or dir';
         });
       },
       default: ()=> Promise.resolve()
@@ -231,7 +222,7 @@ class Platform {
   static getUserPath_win32() {
     return pify(child_process.exec)(
       'powershell.exe -executionpolicy bypass -command "[Environment]::GetEnvironmentVariable(\'path\', \'User\');[Environment]::Exit(0);"'
-    ).then(result=> Promise.resolve(result.replace(/\r?\n/g, '')));
+    ).then(result=> result.replace(/\r?\n/g, ''));
   }
 
   static setUserPath_win32(newPath) {

--- a/test/unit/services/platform-test.js
+++ b/test/unit/services/platform-test.js
@@ -328,7 +328,7 @@ describe('Platform', function() {
         sandbox.stub(Platform, 'getOS').returns('darwin');
       });
       it('should return Unknown as version', function() {
-        return Platform.getHypervisorVersion  ().then((result) => {
+        return Platform.getHypervisorVersion().then((result) => {
           expect(result).to.be.equal('Unknown');
         });
       });
@@ -339,7 +339,7 @@ describe('Platform', function() {
         sandbox.stub(Platform, 'getOS').returns('linux');
       });
       it('should return Unknown as version', function() {
-        return Platform.getHypervisorVersion  ().then((result) => {
+        return Platform.getHypervisorVersion().then((result) => {
           expect(result).to.be.equal('Unknown');
         });
       });
@@ -353,7 +353,7 @@ describe('Platform', function() {
 
       it('should return promise resolved to true if powershell script returns `Enabled` in stdout', function() {
         sandbox.stub(child_process, 'exec').yields(undefined, '10.0.123.1345');
-        return Platform.getHypervisorVersion  ().then((result) => {
+        return Platform.getHypervisorVersion().then((result) => {
           expect(result).to.be.equal('10.0.123.1345');
         });
       });


### PR DESCRIPTION
Form documentation for `Promise.prototype.then(onFullfilled, onRejected)` [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then):
"returns a value, the promise returned by then gets resolved with the returned value as its value;"