### PR TITLE
Add prefix \\?\ for target install folder when removing it in

### DIFF
--- a/uninstaller/uninstall-helper.ps1
+++ b/uninstaller/uninstall-helper.ps1
@@ -55,7 +55,7 @@ $targetFolder = [System.IO.Path]::GetFullPath((Join-Path ($folder) '..'))
 
 echo 'Removing installation folder'
 
-Remove-Item -path "$targetFolder" -Force -Recurse
+Remove-Item -path "\\?\$targetFolder" -Force -Recurse
 
 echo 'DONE'
 


### PR DESCRIPTION
This let uninstaller to deal correctly with long file names