### PR TITLE
Hide the entire detection div when it is not in use

### DIFF
--- a/browser/directives/componentPanel.html
+++ b/browser/directives/componentPanel.html
@@ -14,8 +14,8 @@
         <div id="{{item.keyName}}-description">{{item.productDesc}}</div>
       </div>
     </div>
-    <div class="detected-container">
-      <span id="{{item.keyName}}-installed-note" ng-show="item.hasOption('detected') && item.selectedOption === 'detected'">
+    <div class="detected-container" ng-show="item.hasOption('detected') && item.selectedOption === 'detected'">
+      <span id="{{item.keyName}}-installed-note">
         <i class="pficon-ok"></i> Using detected version {{item.option.detected.version}}
       </span>
       <div ng-show="item.hasOption('detected')" style="padding-left: 10px;" class="inline">


### PR DESCRIPTION
to avoid something like this:
![screenshot from 2017-12-12 08-36-04](https://user-images.githubusercontent.com/4181232/33872691-321c1d4a-df18-11e7-9915-7201a03ae6df.png)
