### PR TITLE
Update kompose to 1.7.0.TP

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -306,21 +306,21 @@
         "url": "https://github.com/kubernetes-incubator/kompose/releases/download/v1.7.0/kompose-windows-amd64.exe",
         "fileName": "kompose-1.7.0.TP-windows-amd64.exe",
         "sha256sum": "ea1775ffba33e26e15d25a9540c2b5d65a47b6593adccbe3687fc504f30f8d4c",
-        "size": 47578112,
+        "size": 47712768,
         "installSize": 47578112
       },
       "darwin": {
         "url": "https://github.com/kubernetes-incubator/kompose/releases/download/v1.7.0/kompose-darwin-amd64",
         "fileName": "kompose-1.7.0.TP-darwin-amd64",
         "sha256sum": "7810694432641452fb1327d40b7b04e2a7b71bb88b0c06947003141d619d3738",
-        "size": 47245088,
+        "size": 47305936,
         "installSize": 47245088
       },
       "linux": {
         "url": "https://github.com/kubernetes/kompose/releases/download/v1.7.0/kompose-linux-amd64",
         "fileName": "kompose-1.7.0.TP-linux-amd64",
         "sha256sum": "7810694432641452fb1327d40b7b04e2a7b71bb88b0c06947003141d619d3738",
-        "size": 47823558,
+        "size": 47880590,
         "installSize": 47823558
       }
     }

--- a/requirements.json
+++ b/requirements.json
@@ -289,7 +289,7 @@
     "installable": true,
     "detectable": false,
     "targetFolderName": "kompose",
-    "version": "1.3.0 Technology Preview",
+    "version": "1.7.0 Technology Preview",
     "installAfter": "cdk",
     "channel" : {
       "containerDev": { }
@@ -303,23 +303,23 @@
     },
     "platform": {
       "win32": {
-        "url": "https://developers.redhat.com/redirect/to/kompose-windows-1.3.0.download",
-        "fileName": "kompose-1.3.0.TP-windows-amd64.exe",
-        "sha256sum": "2af9fbcc05eafd2ca6d527fdb1cf1219df5ab1d145d856d1d6ea01f2fb4aa6ed",
+        "url": "https://github.com/kubernetes-incubator/kompose/releases/download/v1.7.0/kompose-windows-amd64.exe",
+        "fileName": "kompose-1.7.0.TP-windows-amd64.exe",
+        "sha256sum": "ea1775ffba33e26e15d25a9540c2b5d65a47b6593adccbe3687fc504f30f8d4c",
         "size": 47578112,
         "installSize": 47578112
       },
       "darwin": {
-        "url": "https://developers.redhat.com/redirect/to/kompose-macos-1.3.0.download",
-        "fileName": "kompose-1.3.0.TP-darwin-amd64",
-        "sha256sum": "878399716ddde73e03d204dadd76af73c30e8eda41d7df5815ddd76ff7193cb0",
+        "url": "https://github.com/kubernetes-incubator/kompose/releases/download/v1.7.0/kompose-darwin-amd64",
+        "fileName": "kompose-1.7.0.TP-darwin-amd64",
+        "sha256sum": "7810694432641452fb1327d40b7b04e2a7b71bb88b0c06947003141d619d3738",
         "size": 47245088,
         "installSize": 47245088
       },
       "linux": {
-        "url": "https://github.com/kubernetes/kompose/releases/download/v1.3.0/kompose-linux-amd64",
-        "fileName": "kompose-1.3.0.TP-linux-amd64",
-        "sha256sum": "615e35f51ab5e477252cecc3aa40bddc5a5a5a316cdb8143785c876b9b81a6c2",
+        "url": "https://github.com/kubernetes/kompose/releases/download/v1.7.0/kompose-linux-amd64",
+        "fileName": "kompose-1.7.0.TP-linux-amd64",
+        "sha256sum": "7810694432641452fb1327d40b7b04e2a7b71bb88b0c06947003141d619d3738",
         "size": 47823558,
         "installSize": 47823558
       }


### PR DESCRIPTION
This fix includes kompose [1.7.0](https://github.com/kubernetes/kompose/releases/tag/v1.7.0) into installer 