### PR TITLE
Use developers portal redirects to download kompose 1.7.0 release

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -303,14 +303,14 @@
     },
     "platform": {
       "win32": {
-        "url": "https://github.com/kubernetes-incubator/kompose/releases/download/v1.7.0/kompose-windows-amd64.exe",
+        "url": "https://developers.redhat.com/redirect/to/kompose-windows-1.7.0.download",
         "fileName": "kompose-1.7.0.TP-windows-amd64.exe",
         "sha256sum": "ea1775ffba33e26e15d25a9540c2b5d65a47b6593adccbe3687fc504f30f8d4c",
         "size": 47712768,
         "installSize": 47578112
       },
       "darwin": {
-        "url": "https://github.com/kubernetes-incubator/kompose/releases/download/v1.7.0/kompose-darwin-amd64",
+        "url": "https://developers.redhat.com/redirect/to/kompose-macos-1.7.0.download",
         "fileName": "kompose-1.7.0.TP-darwin-amd64",
         "sha256sum": "7810694432641452fb1327d40b7b04e2a7b71bb88b0c06947003141d619d3738",
         "size": 47305936,


### PR DESCRIPTION
Release when https://issues.jboss.org/browse/RHDENG-1892 pushed to production.