### PR TITLE
Move prefetch-all task from dist-win.js to gulpfile

### DIFF
--- a/gulp-tasks/dist-win32.js
+++ b/gulp-tasks/dist-win32.js
@@ -129,11 +129,6 @@ module.exports = function(gulp, reqs) {
     return download.prefetch(reqs, 'tools', toolsFolder);
   });
 
-  gulp.task('prefetch-all', ['create-prefetch-cache-dir'], function() {
-    return download.prefetch(reqs, 'no', config.prefetchFolder).then(()=>{
-      return download.prefetch(reqs, 'yes', config.prefetchFolder);
-    });
-  });
 
   gulp.task('create-tools-dir', function() {
     if (!fs.existsSync(toolsFolder)) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -16,6 +16,7 @@ var fs = require('fs-extra'),
   sourcemaps = require('gulp-sourcemaps'),
   symlink = require('gulp-symlink'),
   common = require('./gulp-tasks/common'),
+  download = require('./gulp-tasks/download'),
   config = require('./gulp-tasks/config'),
   yargs = require('yargs');
 
@@ -26,6 +27,12 @@ process.on('uncaughtException', function(err) {
   if(err) {
     throw err;
   }
+});
+
+gulp.task('prefetch-all', ['create-prefetch-cache-dir'], function() {
+  return download.prefetch(reqs, 'no', config.prefetchFolder).then(()=>{
+    return download.prefetch(reqs, 'yes', config.prefetchFolder);
+  });
 });
 
 // transpile sources and copy resources to a separate folder


### PR DESCRIPTION
Fix allows to run https fake server to minic download manager on macOS and windows.