### PR TITLE
Fix uninstaller failing on a single subfolder (fix #1232)

### DIFF
--- a/uninstaller/uninstall-helper.ps1
+++ b/uninstaller/uninstall-helper.ps1
@@ -4,7 +4,7 @@ for ($i=0; $i -le $args.Count - 1; $i++) {
 }
 $timeStamp = $args[-1]
 
-$subfolders = Get-ChildItem "$folder\.." -Directory -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
+[array]$subfolders = Get-ChildItem "$folder\.." -Directory -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
 
 for ($i=0; $i -le $subfolders.Count - 1; $i++) {
   $Source = $subfolders[$i]


### PR DESCRIPTION
Enforce get-childitem to return an array no matter how many subfolders it finds, so the for loop always iterates over the same type.