### PR TITLE
Simplify installation ordering

### DIFF
--- a/browser/pages/selection/controller.js
+++ b/browser/pages/selection/controller.js
@@ -87,11 +87,18 @@ class SelectionController {
 
   initPage() {
     return this.detectInstalledComponents().then(()=> {
+      let checkboxModel = this.sc.checkboxModel;
+      if (checkboxModel.hyperv && checkboxModel.hyperv.isConfigured()) {
+        this.loader.removeComponent('virtualbox');
+      } else {
+        this.loader.removeComponent('hyperv');
+      }
       this.graph = ComponentLoader.loadGraph(this.installerDataSvc);
       this.installWatchers();
     }).then(
       ()=> this.setIsDisabled()
-    ).catch(()=> {
+    ).catch((error)=> {
+      console.error(error);
       this.setIsDisabled();
     });
   }
@@ -160,13 +167,7 @@ class SelectionController {
 
   // Prep the install location path for each product, then go to the next page.
   next() {
-    let checkboxModel = this.sc.checkboxModel;
-    if (checkboxModel.hyperv && checkboxModel.hyperv.isConfigured()) {
-      this.loader.removeComponent('virtualbox');
-    } else {
-      this.loader.removeComponent('hyperv');
-    }
-
+    this.loader.orderInstallation(this.graph);
     let possibleComponents = ['virtualbox', 'jdk', 'devstudio', 'jbosseap', 'cygwin', 'cdk', 'kompose', 'fuseplatform', 'fuseplatformkaraf'];
     for (let i = 0; i < possibleComponents.length; i++) {
       let component = this.installerDataSvc.getInstallable(possibleComponents[i]);

--- a/requirements.json
+++ b/requirements.json
@@ -35,7 +35,6 @@
     "detectable": false,
     "bundle": "no",
     "targetFolderName": "developer-studio",
-    "installAfter": "jbosseap",
     "ius": [
       "org.jboss.tools.windup.feature.feature.group"
     ],
@@ -138,7 +137,6 @@
     "detectable": false,
     "bundle": "no",
     "targetFolderName": "developer-studio",
-    "installAfter": "devstuidocentralcheckstyle",
     "ius": [
       "org.jboss.tools.bpel.feature.feature.group",
       "org.eclipse.bpmn2.feature.feature.group",
@@ -169,7 +167,6 @@
     "modulePath": "model/jdk-install",
     "targetFolderName": "jdk8",
     "detectable": true,
-    "installAfter": "kompose",
     "platform": {
       "win32": {
         "name": "OpenJDK",
@@ -255,8 +252,7 @@
         "version": "3.3.0-GA",
         "size": 481787904,
         "installSize" : 7243047404,
-        "requires": ["cygwin","hyperv||virtualbox"],
-        "installAfter": "cygwin"
+        "requires": ["cygwin","hyperv||virtualbox"]
       },
       "darwin": {
         "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/cdk-3.3.0-1-minishift-darwin-amd64?workflow=direct",
@@ -266,8 +262,7 @@
         "version": "3.3.0-GA",
         "size": 483310592,
         "installSize" : 7243047404,
-        "requires": ["virtualbox"],
-        "installAfter": "virtualbox"
+        "requires": ["virtualbox"]
       },
       "linux": {
         "dmUrl": "http://cdk-builds.usersys.redhat.com/builds/weekly/16-Jan-2018.cdk-3.3.0/linux-amd64/minishift",
@@ -277,8 +272,7 @@
         "version": "3.3.0-GA",
         "size": 481478720,
         "installSize" : 836390912,
-        "requires": ["virtualbox"],
-        "installAfter": "virtualbox"
+        "requires": ["virtualbox"]
       }
     }
   },
@@ -365,7 +359,6 @@
     "installable": true,
     "bundle": "no",
     "targetFolderName": "jboss-fuse-eap",
-    "installAfter": "fusetools",
     "version": "6.3.0.GA",
     "size": 228052992,
     "installSize": 1045204992,
@@ -402,7 +395,6 @@
      "installable": true,
      "bundle": "no",
      "targetFolderName": "jboss-fuse-karaf",
-     "installAfter": "fuseplatform",
      "version": "6.3.0.GA",
      "size": 785784505,
      "installSize": 1129381888,
@@ -427,7 +419,6 @@
     "detectable": false,
     "bundle": "no",
     "targetFolderName": "jbosseap",
-    "installAfter": "fuseplatformkaraf",
     "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/jboss-eap-7.1.0-installer.jar?workflow=direct",
     "url": "http://download-node-02.eng.bos.redhat.com/released/JBEAP-7/7.1.0/jboss-eap-7.1.0-installer.jar",
     "fileName": "jboss-eap-7.1.0-installer.jar",
@@ -545,7 +536,6 @@
     "detectable": true,
     "bundle": "always",
     "targetFolderName": "cygwin",
-    "installAfter": "virtualbox",
     "url": "https://cygwin.com/setup-x86_64.exe",
     "fileName": "cygwin_2.10.0.exe",
     "sha256sum": "22d80e6893200d377bdb46a7080d3c60092e027bba51c6e73013969e05c629f9",

--- a/requirements.json
+++ b/requirements.json
@@ -8,7 +8,6 @@
     "detectable": false,
     "bundle": "yes",
     "targetFolderName": "developer-studio",
-    "installAfter": "jdk",
     "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/devstudio-11.2.0.GA-installer-standalone.jar?workflow=direct",
     "url": "https://devstudio.redhat.com/11/staging/builds/devstudio-11.2.0.GA-build-product/latest/all/devstudio-11.2.0.GA-installer-standalone.jar",
     "fileName": "devstudio-11.2.0.GA-installer-standalone.jar",
@@ -59,7 +58,6 @@
     "installable": true,
     "detectable": false,
     "bundle": "no",
-    "installAfter": "devstuidorhamt",
     "dmUrl": "https://developers.redhat.com/download-manager/jdf/file/devstudio-11.2.0.GA-updatesite-central.zip?workflow=direct",
     "url": "https://devstudio.redhat.com/11/staging/builds/devstudio-11.2.0.GA-build-product/latest/all/devstudio-11.2.0.GA-updatesite-central.zip",
     "fileName": "devstudio-11.2.0.GA-updatesite-central.zip",
@@ -84,7 +82,6 @@
     "detectable": false,
     "bundle": "no",
     "targetFolderName": "developer-studio",
-    "installAfter": "devstudiocentral",
     "ius": [
       "org.jboss.tools.jst.angularjs.feature.feature.group"
     ],
@@ -110,7 +107,6 @@
     "detectable": false,
     "bundle": "no",
     "targetFolderName": "developer-studio",
-    "installAfter": "devstuidocentralangularjs",
     "ius": [
       "net.sf.eclipsecs.feature.group",
       "com.github.sevntu.checkstyle.checks.feature.feature.group"
@@ -286,7 +282,6 @@
     "bundle": "no",
     "targetFolderName": "kompose",
     "version": "1.7.0 Technology Preview",
-    "installAfter": "cdk",
     "channel" : {
       "containerDev": { }
     },
@@ -333,7 +328,6 @@
     "detectable": false,
     "bundle": "no",
     "targetFolderName": "developer-studio",
-    "installAfter": "devstudio",
     "url": "https://devstudio.redhat.com/11/",
     "fileName": "devstudio-11.2.0.GA-installer-standalone.jar",
     "sha256sum": "",
@@ -559,7 +553,6 @@
     "detectable": false,
     "bundle": "no",
     "useDownload": false,
-    "installAfter": "devstuidobpm",
     "url": "https://www.eclipse.org/che/",
     "version": "5.0 Technology Preview",
     "size": 0,
@@ -579,7 +572,6 @@
     "detectable": false,
     "bundle": "no",
     "targetFolderName": "developer-studio",
-    "installAfter": "cdkcheaddon",
     "ius": [
       "net.java.dev.jna.feature.group",
       "org.tigris.subversion.subclipse.feature.group",
@@ -609,7 +601,6 @@
     "detectable": false,
     "bundle": "no",
     "targetFolderName": "developer-studio",
-    "installAfter": "devstuiocentralsubclipse",
     "ius": [
       "org.sonarlint.eclipse.feature.feature.group"
     ],

--- a/test/unit/pages/selection/controller-test.js
+++ b/test/unit/pages/selection/controller-test.js
@@ -339,8 +339,10 @@ describe('SelectionController', function() {
   describe('next', function() {
     beforeEach(inject(context));
     it('stould navidate to confirmation page', function() {
-      selectionController.next();
-      expect(selectionController.router.go).calledWith('confirm');
+      return selectionController.initPage().then(function(){
+        selectionController.next();
+        expect(selectionController.router.go).calledWith('confirm');
+      });
     });
   });
 });

--- a/test/unit/services/componentLoader-test.js
+++ b/test/unit/services/componentLoader-test.js
@@ -135,26 +135,13 @@ describe('Component Loader', function() {
       svc = new InstallerDataService({}, reqs);
       loader = new ComponentLoader(svc);
       addAll(loader, reqs);
-      loader.orderInstallation();
+      loader.orderInstallation(ComponentLoader.loadGraph(svc));
 
-      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('jdk').installAfter.keyName).to.equal('cdk');
       expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
-      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
-    });
-
-    it('if the first component in sequence is not present, its children should take its place', function() {
-      svc = new InstallerDataService({}, reducedReqs);
-      loader = new ComponentLoader(svc);
-      addAll(loader, reducedReqs);
-      loader.orderInstallation();
-
-      expect(svc.getInstallable('jdk')).to.equal(undefined);
-      expect(svc.getInstallable('devstudio').installAfter).to.equal(undefined);
-      expect(svc.getInstallable('virtualbox').installAfter).to.equal(undefined);
-      expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
-      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
+      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('cygwin');
+      expect(svc.getInstallable('cygwin').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('virtualbox');
     });
   });
 
@@ -163,7 +150,7 @@ describe('Component Loader', function() {
       svc = new InstallerDataService({}, reqs);
       loader = new ComponentLoader(svc);
       addAll(loader, reqs);
-      loader.orderInstallation();
+      loader.orderInstallation(ComponentLoader.loadGraph(svc));
     });
 
     it('should delete the appropriate component', function() {
@@ -176,16 +163,6 @@ describe('Component Loader', function() {
       expect(svc.toDownload.has('cdk')).to.be.false;
       expect(svc.toInstall.has('cdk')).to.be.false;
     });
-
-    it('should rearange the installation sequence', function() {
-      loader.removeComponent('cygwin');
-
-      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
-      expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('cygwin')).to.equal(undefined);
-      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('virtualbox');
-    });
   });
 
   describe('loadComponent', function() {
@@ -193,22 +170,11 @@ describe('Component Loader', function() {
       svc = new InstallerDataService({}, reqs);
       loader = new ComponentLoader(svc);
       addAll(loader, reducedReqs);
-      loader.orderInstallation();
     });
 
     it('should add the specified component', function() {
       loader.loadComponent('jdk');
       expect(svc.getInstallable('jdk')).to.not.equal(undefined);
-    });
-
-    it('should rearange the installation sequence', function() {
-      loader.loadComponent('jdk');
-
-      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
-      expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
-      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
     });
   });
 
@@ -216,11 +182,11 @@ describe('Component Loader', function() {
     beforeEach(function() {
       svc = new InstallerDataService({}, reqs);
       loader = new ComponentLoader(svc);
+      loader.loadComponents();
+      loader.orderInstallation(ComponentLoader.loadGraph(svc));
     });
 
     it('should add all the components from the requirements', function() {
-      loader.loadComponents();
-
       expect(svc.getInstallable('jdk')).to.not.equal(undefined);
       expect(svc.getInstallable('devstudio')).to.not.equal(undefined);
       expect(svc.getInstallable('virtualbox')).to.not.equal(undefined);
@@ -229,13 +195,11 @@ describe('Component Loader', function() {
     });
 
     it('should order the installation sequence', function() {
-      loader.loadComponents();
-
-      expect(svc.getInstallable('jdk').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('jdk').installAfter.keyName).to.equal('cdk');
       expect(svc.getInstallable('devstudio').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('jdk');
-      expect(svc.getInstallable('cygwin').installAfter.keyName).to.equal('virtualbox');
-      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('cygwin');
+      expect(svc.getInstallable('virtualbox').installAfter.keyName).to.equal('cygwin');
+      expect(svc.getInstallable('cygwin').installAfter).to.equal(undefined);
+      expect(svc.getInstallable('cdk').installAfter.keyName).to.equal('virtualbox');
     });
   });
 });


### PR DESCRIPTION
This fix gets read of installAfter hell in requirements.json. It flatten graph or components and then just set installAfter in simple cycle. Net step would be getting rid of installAfter notion. Installation would just go in cycle for flatten requirements graph.