### PR TITLE
Download to global appdata folder (at least for windows)

### DIFF
--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -51,7 +51,7 @@ class InstallableItem {
     this.selectedOption = requirement.defaultOption ? requirement.defaultOption : 'install';
 
     this.downloader = null;
-    this.downloadFolder = path.join(this.installerDataSvc.localAppData(), 'cache');
+    this.downloadFolder = path.join(this.installerDataSvc.programData(), 'cache');
     if(!fs.existsSync(this.downloadFolder)) {
       mkdirp.sync(this.downloadFolder);
     }

--- a/browser/services/data.js
+++ b/browser/services/data.js
@@ -223,6 +223,10 @@ class InstallerDataService {
     return Platform.localAppData();
   }
 
+  programData() {
+    return Platform.programData();
+  }
+
   isDownloading() {
     return this.downloading;
   }

--- a/browser/services/platform.js
+++ b/browser/services/platform.js
@@ -269,10 +269,10 @@ class Platform {
   }
 
   static localAppData() {
-    let appData = Platform.identify({
+    return Platform.identify({
       win32: ()=> {
-        let appDataPath = Platform.ENV.APPDATA;
-        return appDataPath ? path.join(appDataPath, '..', 'Local', 'RedHat', 'DevSuite') : os.tmpdir();
+        let appDataPath = Platform.ENV.LOCALAPPDATA;
+        return appDataPath ? path.join(appDataPath, 'RedHat', 'DevSuite') : os.tmpdir();
       }, darwin: ()=> {
         let homePath = Platform.ENV.HOME;
         return homePath ? path.join(homePath, 'Library', 'Application Support', 'RedHat', 'DevSuite') : os.tmpdir();
@@ -280,7 +280,20 @@ class Platform {
         return os.tmpdir();
       }
     });
-    return path.resolve(appData);
+  }
+
+  static programData() {
+    return Platform.identify({
+      win32: () => {
+        let programDataPath = Platform.ENV.ALLUSERSPROFILE;
+        return programDataPath ? path.join(programDataPath, 'RedHat', 'DevSuite') : os.tmpdir();
+      }, darwin: () => {
+        // use the user specific folder because of permissions
+        return Platform.localAppData();
+      }, default: () => {
+        return os.tmpdir();
+      }
+    });
   }
 }
 

--- a/test/unit/directives/component-panel-test.js
+++ b/test/unit/directives/component-panel-test.js
@@ -48,6 +48,7 @@ describe('ComponentPanelDirective', function() {
     ds.getPassword.returns('password');
     ds.komposeDir.returns(path.join(ds.installDir(), 'kompose'));
     ds.localAppData.restore();
+    ds.programData.restore();
     return ds;
   }
 

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -28,6 +28,7 @@ describe('CDK installer', function() {
   installerDataSvc = sinon.stub(new InstallerDataService());
   installerDataSvc.getRequirementByName.restore();
   installerDataSvc.localAppData.restore();
+  installerDataSvc.programData.restore();
   installerDataSvc.tempDir.returns('temporaryFolder');
   installerDataSvc.installDir.returns('installFolder');
   installerDataSvc.getUsername.returns('user');

--- a/test/unit/model/che-test.js
+++ b/test/unit/model/che-test.js
@@ -12,7 +12,7 @@ import CheInstall from 'browser/model/che';
 chai.use(sinonChai);
 let sinon  = require('sinon');
 
-describe('CDK installer', function() {
+describe('Che installer', function() {
   let sandbox, installerDataSvc;
   let infoStub, errorStub;
 
@@ -21,6 +21,7 @@ describe('CDK installer', function() {
   installerDataSvc = sinon.stub(new InstallerDataService());
   installerDataSvc.getRequirementByName.restore();
   installerDataSvc.localAppData.restore();
+  installerDataSvc.programData.restore();
   installerDataSvc.tempDir.returns('temporaryFolder');
   installerDataSvc.installDir.returns('installFolder');
   installerDataSvc.getUsername.returns('user');

--- a/test/unit/model/cygwin-test.js
+++ b/test/unit/model/cygwin-test.js
@@ -38,6 +38,7 @@ describe('Cygwin installer', function() {
   installerDataSvc.cygwinDir.returns('install/Cygwin');
   installerDataSvc.getInstallable.returns(fakeInstallable);
   installerDataSvc.localAppData.restore();
+  installerDataSvc.programData.restore();
 
   let fakeProgress;
 

--- a/test/unit/model/devstudio-test.js
+++ b/test/unit/model/devstudio-test.js
@@ -49,6 +49,7 @@ describe('devstudio installer', function() {
     ds.getUsername.returns('user');
     ds.getPassword.returns('passwd');
     ds.localAppData.restore();
+    ds.programData.restore();
     return ds;
   }
 

--- a/test/unit/model/devstudiop2-test.js
+++ b/test/unit/model/devstudiop2-test.js
@@ -40,6 +40,7 @@ describe('devstudiop2 central installer', function() {
     ds.getUsername.returns('user');
     ds.getPassword.returns('passwd');
     ds.localAppData.restore();
+    ds.programData.restore();
     return ds;
   }
 

--- a/test/unit/model/jbosseap-test.js
+++ b/test/unit/model/jbosseap-test.js
@@ -54,6 +54,7 @@ describe('jbosseap installer', function() {
     ds.getPassword.returns('passwd');
     ds.devstudioDir.returns('installationFolder/devstudio');
     ds.localAppData.restore();
+    ds.programData.restore();
     return ds;
   }
 

--- a/test/unit/model/jbossfuse-test.js
+++ b/test/unit/model/jbossfuse-test.js
@@ -66,6 +66,7 @@ describe('fuseplatform installer', function() {
     ds.getPassword.returns('passwd');
     ds.devstudioDir.returns('installationFolder/devstudio');
     ds.localAppData.restore();
+    ds.programData.restore();
     return ds;
   }
 

--- a/test/unit/model/jdk-install-test.js
+++ b/test/unit/model/jdk-install-test.js
@@ -32,6 +32,7 @@ describe('JDK installer', function() {
   installerDataSvc.getUsername.returns('user');
   installerDataSvc.getPassword.returns('passwd');
   installerDataSvc.localAppData.restore();
+  installerDataSvc.programData.restore();
 
   let fakeProgress;
 

--- a/test/unit/model/kompose-test.js
+++ b/test/unit/model/kompose-test.js
@@ -33,6 +33,7 @@ describe('kompose installer', function() {
   installerDataSvc.getPassword.returns('password');
   installerDataSvc.komposeDir.returns(path.join(installerDataSvc.installDir(), 'kompose'));
   installerDataSvc.localAppData.restore();
+  installerDataSvc.programData.restore();
 
   let installer;
 

--- a/test/unit/model/virtualbox-test.js
+++ b/test/unit/model/virtualbox-test.js
@@ -64,6 +64,7 @@ describe('Virtualbox installer', function() {
     installerDataSvc.installDir.returns('installationFolder');
     installerDataSvc.virtualBoxDir.returns('installationFolder/virtualbox');
     installerDataSvc.localAppData.restore();
+    installerDataSvc.programData.restore();
     item2 = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', installerDataSvc);
     installer = new VirtualBoxInstall(installerDataSvc, 'virtualbox', downloadUrl, 'virtualbox.exe', 'sha', version, revision);
     installer.ipcRenderer = { on: function() {} };


### PR DESCRIPTION
- changes the download folder so all windows users can utilize them
- the config is still in the user's appdata
- mac doesn't permit writing into a shared folder without elevated privileges