### PR TITLE
Replace osascript with sudo prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ of Vagrant and VirtualBox (will download them):
 5. To build both installers in a single step:
 
         npm run dist
-        
+
 Running installer behind proxy
 ------------------------------
 
@@ -232,8 +232,8 @@ and raw coverage reports. The report format can be overridden with `--report`
 parameter like shown below
 
     npm test -- --report cobertura
-    
-To open html coverage report in your default browser after unit tests finished use 
+
+To open html coverage report in your default browser after unit tests finished use
 `--open-report` option
 
     npm test -- --spec-file=test/unit/pages/**/*.js --open-report
@@ -241,7 +241,7 @@ To open html coverage report in your default browser after unit tests finished u
 Running unit tests one by one for each installer module
 
     gulp unit-test-1by1
-    
+
 If you experience this error when running unit tests
 
     module.js:598
@@ -255,7 +255,7 @@ If you experience this error when running unit tests
 install 'keytar' module using npm
 
     npm install keytar
-    
+
 Debugging unit tests
 --------------------
 
@@ -384,8 +384,8 @@ without Administrative privileges.
 
 #### macOS
 
-On macOS, installer starts with osascript that requests administrative account
-credential to continue. So you can run from any bash instance and installer will show request
+On macOS, installer may request administrative account
+credentials to continue. So you can run from any bash instance and installer will show request
 for account with rights to administer current machine.
 
 Updating dependencies to latest

--- a/browser/model/helpers/installer.js
+++ b/browser/model/helpers/installer.js
@@ -5,6 +5,7 @@ let child_process = require('child_process');
 let unzip = require('unzip');
 let targz = require('targz');
 
+import sudo from 'sudo-prompt';
 import Logger from '../../services/logger';
 
 class Installer {
@@ -33,6 +34,25 @@ class Installer {
         }
       });
     });
+  }
+
+  execElevated(command, options = {name: 'Red Hat Development Suite', icns: 'resources/devsuite.icns'}) {
+    return new Promise((resolve, reject) => {
+      Logger.info(this.key + ' - Execute command ' + command);
+      sudo.exec(command, options, (error, stdout, stderr) => {
+        if (error) {
+          Logger.error(this.key + ' - ' + error);
+          Logger.error(this.key + ' - ' + stderr);
+          reject(error);
+        } else {
+          if (stdout) {
+            Logger.info(this.key + ' - ' + stdout);
+          }
+          Logger.info(this.key + ' - Execute ' + command + ' SUCCESS');
+          resolve(true);
+        }
+      });
+    })
   }
 
   execFile(file, args, options = {}) {

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -239,6 +239,8 @@ class VirtualBoxInstallDarwin extends VirtualBoxInstall {
     progress.setStatus('Installing');
     let installer = new Installer(this.keyName, progress, success, failure);
     return installer.exec(this.getScript()).then((result) => {
+      return installer.execElevated(this.getSudoScript());
+    }).then((result) => {
       installer.succeed(result);
     }).catch((error) => {
       installer.fail(error);
@@ -247,18 +249,14 @@ class VirtualBoxInstallDarwin extends VirtualBoxInstall {
 
   getScript() {
     let dmgFile = this.downloadedFile;
-    //let timestamp = new Date().toJSON().replace(/:/g,'')
     let volumeName = `virtualbox-${this.version}`;
-    let shellScript = [
-      `hdiutil attach -mountpoint /Volumes/${volumeName}  '${dmgFile}'`,
-      `installer -pkg /Volumes/${volumeName}/VirtualBox.pkg -target /`
-    ].join(';');
-    let osaScript = [
-      'osascript',
-      '-e',
-      `"do shell script \\"${shellScript}\\" with administrator privileges"`
-    ].join(' ');
-    return osaScript;
+    let script = `hdiutil attach -mountpoint /Volumes/${volumeName}  '${dmgFile}'`;
+    return script;
+  }
+
+  getSudoScript() {
+    let volumeName = `virtualbox-${this.version}`;
+    return `installer -pkg /Volumes/${volumeName}/VirtualBox.pkg -target /`;
   }
 }
 

--- a/browser/pages/install/install.html
+++ b/browser/pages/install/install.html
@@ -6,7 +6,7 @@
   </div>
   <div class="alert install-info" ng-show="instCtrl.isDarwinPlatform()">
     <span class="pficon pficon-info"></span>
-    <strong>The authentication dialog may appear several times and will read: "osascript wants to make changes".</strong>
+    <strong>The authentication dialog may appear several times.</strong>
   </div>
   <div class="panel-default">
     <div class="panel-body">

--- a/browser/services/platform.js
+++ b/browser/services/platform.js
@@ -5,6 +5,7 @@ const pify = require('pify');
 const path = require('path');
 const fs = require('fs-extra');
 import os from 'os';
+import sudo from 'sudo-prompt';
 
 class Platform {
   static identify(map) {
@@ -258,14 +259,9 @@ class Platform {
     let commands = [];
     executables.forEach(function(executable) {
       let name = path.parse(executable).name;
-      commands.push(`rm -f /usr/local/bin/${name}; ln -s '${executable}' /usr/local/bin/${name};`);
+      commands.push(`rm -f /usr/local/bin/${name};ln -s '${executable}' /usr/local/bin/${name};`);
     });
-    let osaScript = [
-      'osascript',
-      '-e',
-      `"do shell script \\"${commands.join(' ')}\\" with administrator privileges"`
-    ];
-    return pify(child_process.exec)(osaScript.join(' '));
+    return pify(sudo.exec)(commands.join(''), {name: 'Red Hat Development Suite', icns: 'resources/devsuite.icns'});
   }
 
   static localAppData() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13151,6 +13151,11 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "sudo-prompt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.1.0.tgz",
+      "integrity": "sha512-ldRmDX+pC/Z3iroh4mTFrCxtt0B6KSlJNDQ9r1CvmWwW3ONi6OCY6YWEH2At71fYTEQ/9kXXke7FvtdqfusN6g=="
+    },
     "sumchecker": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "request": "2.83.0",
     "rimraf": "2.6.2",
     "semver": "5.5.0",
+    "sudo-prompt": "8.1.0",
     "targz": "1.0.1",
     "unzip": "0.1.11",
     "unzip-stream": "0.2.2",

--- a/test/unit/model/virtualbox-test.js
+++ b/test/unit/model/virtualbox-test.js
@@ -129,6 +129,8 @@ describe('Virtualbox installer', function() {
 
     describe('on macos', function() {
       beforeEach(function() {
+        sandbox.stub(Installer.prototype, 'exec').resolves(true);
+        sandbox.stub(Installer.prototype, 'execElevated').resolves(true);
         helper = new Installer('virtualbox', fakeProgress);
         sandbox.stub(Platform, 'getOS').returns('macOS');
         downloadedFile = path.join(installerDataSvc.localAppData(), 'cache', 'virtualbox.exe');
@@ -136,10 +138,18 @@ describe('Virtualbox installer', function() {
         installer.ipcRenderer = {on: function() {}};
       });
 
-      it('should execute macos installer with osascript', function() {
-        sandbox.stub(Installer.prototype, 'exec').resolves(true);
-        installer.installAfterRequirements(fakeProgress, function() {}, function() {});
-        expect(Installer.prototype.exec).calledWith(installer.getScript());
+      it('should mount the dmg file', function() {
+        installer.installAfterRequirements(fakeProgress, function() {}, function() {})
+        .then(() => {
+          expect(Installer.prototype.exec).calledWith(installer.getScript());
+        });
+      });
+
+      it('should run the installer with elevated privileges', function() {
+        installer.installAfterRequirements(fakeProgress, function() {}, function() {})
+        .then(() => {
+          expect(Installer.prototype.execElevated).calledWith(installer.getSudoScript());
+        });
       });
     });
 


### PR DESCRIPTION
Use sudo-prompt to get elevated privileges:
 - use actual sudo instead of osascript elevation
 - customizable auth dialog (name and icon match the product, yay)
 - credentials remain active until invalidated (session runs out / sudo -k)
   - unless tty-tickets is enabled, only one dialog will be presented during the installation