### PR TITLE
Use a different user-agent header for debug/test runs (#fix 1269)

### DIFF
--- a/browser/model/helpers/downloader.js
+++ b/browser/model/helpers/downloader.js
@@ -15,7 +15,6 @@ class Downloader {
     this.success = success;
     this.failure = failure;
     this.downloads = new Map();
-    this.userAgentString = '';
     this.downloaded = 0;
     this.lastTime = 0;
     this.userAgentString = userAgentString;

--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -44,6 +44,10 @@ class InstallableItem {
 
     this.bundleFolder = remote && remote.getCurrentWindow().bundleTempFolder ? remote.getCurrentWindow().bundleTempFolder : path.normalize(path.join(__dirname, '../../../..'));
     this.userAgentString = remote && remote.getCurrentWindow().webContents.session.getUserAgent();
+    if (process.env.DSI_TEST_AGENT) {
+      this.userAgentString = process.env.DSI_TEST_AGENT;
+    }
+
     this.bundledFile = path.join(this.bundleFolder, fileName);
 
     this.isCollapsed = true;

--- a/browser/services/request.js
+++ b/browser/services/request.js
@@ -3,7 +3,7 @@
 class Request {
   constructor(requestMod, $window) {
     this.request = requestMod;
-    this.userAgentString = $window.navigator.userAgent;
+    this.userAgentString = process.env.DSI_TEST_AGENT ? process.env.DSI_TEST_AGENT : $window.navigator.userAgent;
   }
 
   get(req) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,6 +23,8 @@ var fs = require('fs-extra'),
 require('./gulp-tasks/tests')(gulp);
 require('./gulp-tasks/dist-' + process.platform)(gulp, reqs);
 
+var testAgent = 'RedHatDevelopmentSuiteTestInstaller/' + pjson.version + ' test/' + pjson.version;
+
 process.on('uncaughtException', function(err) {
   if(err) {
     throw err;
@@ -109,6 +111,7 @@ gulp.task('generate', ['create-modules-link', 'update-requirements', 'electron-r
 gulp.task('default', ['run-clean']);
 
 gulp.task('run-clean', function(cb) {
+  process.env.DSI_TEST_AGENT = testAgent;
   return runSequence( 'clean-transpiled', 'run', cb);
 });
 
@@ -192,11 +195,13 @@ gulp.task('update-requirements', ['transpile:app'], function() {
 gulp.task('test', ['unit-test']);
 
 gulp.task('ui-test', function(cb) {
+  process.env.DSI_TEST_AGENT = testAgent;
   process.env.PTOR_TEST_RUN = 'ui';
   return runSequence(['generate'], 'protractor-run', cb);
 });
 
 gulp.task('system-test', function(cb) {
+  process.env.DSI_TEST_AGENT = testAgent;
   process.env.PTOR_TEST_RUN = 'system';
   let tasks = [];
   if (process.platform === 'win32') {


### PR DESCRIPTION
so that the http requests for testing purposes can be filtered out in the statistics.
Feel free to edit the agent string itself if you don't like it :)