### PR TITLE
Use machine path rather than user path on windows

### DIFF
--- a/browser/model/cdk.js
+++ b/browser/model/cdk.js
@@ -70,7 +70,9 @@ class CDKInstall extends InstallableItem {
     }).then(()=> {
       return Platform.makeFileExecutable(ocExe);
     }).then(()=> {
-      return Platform.addToUserPath([ocExe, this.minishiftExe]);
+      return Platform.addToUserPath([this.minishiftExe]);
+    }).then(() => {
+      return Platform.addToUserPath([ocExe], 'User');
     }).then(()=> {
       return pify(fs.appendFile)(
         path.join(home, 'cdk'),

--- a/test/unit/model/cdk-test.js
+++ b/test/unit/model/cdk-test.js
@@ -270,9 +270,8 @@ describe('CDK installer', function() {
           installer.installAfterRequirements(fakeProgress, resolve, reject);
         }).then(()=> {
           expect(Platform.addToUserPath).calledWith([
-            path.join(process.cwd(), 'Users', 'dev1', '.minishift', 'cache', 'oc', '1.4.1', 'oc.exe'),
-            path.join('ocBinRoot', 'minishift.exe')
-          ]);
+            path.join(process.cwd(), 'Users', 'dev1', '.minishift', 'cache', 'oc', '1.4.1', 'oc.exe')], 'User');
+          expect(Platform.addToUserPath).calledWith([path.join('ocBinRoot', 'minishift.exe')]);
         });
       });
 
@@ -371,10 +370,9 @@ describe('CDK installer', function() {
         return new Promise((resolve, reject)=> {
           installer.installAfterRequirements(fakeProgress, resolve, reject);
         }).then(()=> {
-          expect(Platform.addToUserPath).to.have.been.calledWith([
-            path.join(process.cwd(), 'minishift-home', 'cache', 'oc', '1.4.1', 'oc.exe'),
-            path.join('ocBinRoot', 'minishift.exe')
-          ]);
+          expect(Platform.addToUserPath).calledWith([
+            path.join(process.cwd(), 'minishift-home', 'cache', 'oc', '1.4.1', 'oc.exe')], 'User');
+          expect(Platform.addToUserPath).calledWith([path.join('ocBinRoot', 'minishift.exe')]);
         });
       });
     });
@@ -414,9 +412,8 @@ describe('CDK installer', function() {
           installer.installAfterRequirements(fakeProgress, resolve, reject);
         }).then(()=>{
           expect(Platform.addToUserPath).calledWith([
-            path.join(process.cwd(), 'Users', 'dev1', '.minishift', 'cache', 'oc', '1.4.1', 'oc'),
-            path.join('ocBinRoot', 'minishift')
-          ]);
+            path.join(process.cwd(), 'Users', 'dev1', '.minishift', 'cache', 'oc', '1.4.1', 'oc')], 'User');
+          expect(Platform.addToUserPath).calledWith([path.join('ocBinRoot', 'minishift')]);
         });
       });
 
@@ -425,10 +422,9 @@ describe('CDK installer', function() {
         return new Promise((resolve, reject)=> {
           installer.installAfterRequirements(fakeProgress, resolve, reject);
         }).then(()=> {
-          expect(Platform.addToUserPath).to.have.been.calledWith([
-            path.join(process.cwd(), 'minishift-home', 'cache', 'oc', '1.4.1', 'oc'),
-            path.join('ocBinRoot', 'minishift')
-          ]);
+          expect(Platform.addToUserPath).calledWith([
+            path.join(process.cwd(), 'minishift-home', 'cache', 'oc', '1.4.1', 'oc')], 'User');
+          expect(Platform.addToUserPath).calledWith([path.join('ocBinRoot', 'minishift')]);
         });
       });
     });

--- a/test/unit/services/platform-test.js
+++ b/test/unit/services/platform-test.js
@@ -594,6 +594,15 @@ describe('Platform', function() {
           expect(Platform.setUserPath_win32).calledWith(['path2', 'path3', 'path1'].join(';'));
         });
       });
+      it('adds items to the Machine path by default', function() {
+        sandbox.stub(child_process, 'exec').yields(undefined, 'path1\r\n');
+        sandbox.stub(Platform, 'setUserPath_win32').returns(Promise.resolve());
+        let spy = sandbox.spy(Platform, 'addToUserPath_win32');
+        let locations = ['path1', 'path2'];
+        return Platform.addToUserPath(locations).then(() => {
+          expect(spy).calledWith(locations, 'Machine');
+        });
+      });
     });
     describe('on macos', function() {
       let executables = [
@@ -643,6 +652,12 @@ describe('Platform', function() {
           expect(child_process.exec.getCall(0).args[0].includes('\'c:\\path\'')).to.be.true;
         });
       });
+      it('uses the machine path as default', function() {
+        sandbox.stub(child_process, 'exec').yields(undefined, '');
+        return Platform.setUserPath('c:\\path').then(() => {
+          expect(child_process.exec.getCall(0).args[0].includes('Machine')).to.be.true;
+        });
+      });
     });
     describe('on linux', function() {
       beforeEach(function() {
@@ -677,6 +692,13 @@ describe('Platform', function() {
         sandbox.stub(Platform, 'setUserPath_win32').returns(Promise.resolve());
         return Platform.removeFromUserPath(locations).then(() => {
           expect(Platform.setUserPath_win32).calledWith('c:\\path4');
+        });
+      });
+      it('uses machine path by default', function() {
+        sandbox.stub(child_process, 'exec').yields(undefined, 'c:\\path1;c:\\path2;c:\\path3;c:\\path4');
+        sandbox.stub(Platform, 'setUserPath_win32').returns(Promise.resolve());
+        return Platform.removeFromUserPath(locations).then(() => {
+          expect(Platform.setUserPath_win32).calledWith('c:\\path4', 'Machine');
         });
       });
     });

--- a/uninstaller/uninstall-helper.ps1
+++ b/uninstaller/uninstall-helper.ps1
@@ -117,17 +117,23 @@ if ($lock) {
   echo 'DONE'
 
   echo 'Removing path entries'
-  [string[]] $pathFolders = [Environment]::GetEnvironmentVariable("Path", "User") -Split ';'
-  [Collections.ArrayList] $folderList = New-Object Collections.Arraylist
+  function Clear-Path {
+    param([string]$type)
+    [string[]] $pathFolders = [Environment]::GetEnvironmentVariable("Path", $type) -Split ';'
+    [Collections.ArrayList] $folderList = New-Object Collections.Arraylist
 
-  $pathFolders | foreach {
-    If (-Not ($_ -like "$targetFolder*")) {
-      $folderList.Add($_) | Out-Null
+    $pathFolders | foreach {
+      If (-Not ($_ -like "$targetFolder*")) {
+        $folderList.Add($_) | Out-Null
+      }
     }
+
+    [string] $delimitedFolders = $folderList -Join ';'
+    [Environment]::SetEnvironmentVariable("Path", $delimitedFolders, $type)
   }
 
-  [string] $delimitedFolders = $folderList -Join ';'
-  [Environment]::SetEnvironmentVariable("Path", $delimitedFolders, "User")
+  Clear-Path -type "User"
+  Clear-Path -type "Machine"
 
   Remove-Item -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\DevelopmentSuite$timeStamp"
 


### PR DESCRIPTION
Since we default to installing into program files, it seemed logical to add items to the system (machine) path rather than the user one. Things like oc still remain on user path since it is installed in user's home.