### PR TITLE
Package icons into the final archive

### DIFF
--- a/browser/model/helpers/installer.js
+++ b/browser/model/helpers/installer.js
@@ -7,6 +7,7 @@ let targz = require('targz');
 
 import sudo from 'sudo-prompt';
 import Logger from '../../services/logger';
+import path from 'path';
 
 class Installer {
 
@@ -36,7 +37,7 @@ class Installer {
     });
   }
 
-  execElevated(command, options = {name: 'Red Hat Development Suite', icns: 'resources/devsuite.icns'}) {
+  execElevated(command, options = {name: 'Red Hat Development Suite', icns: path.resolve(__dirname + '/../../../resources/devsuite.icns')}) {
     return new Promise((resolve, reject) => {
       Logger.info(this.key + ' - Execute command ' + command);
       sudo.exec(command, options, (error, stdout, stderr) => {

--- a/browser/services/platform.js
+++ b/browser/services/platform.js
@@ -278,7 +278,7 @@ class Platform {
       let name = path.parse(executable).name;
       commands.push(`rm -f /usr/local/bin/${name};ln -s '${executable}' /usr/local/bin/${name};`);
     });
-    return pify(sudo.exec)(commands.join(''), {name: 'Red Hat Development Suite', icns: 'resources/devsuite.icns'});
+    return pify(sudo.exec)(commands.join(''), {name: 'Red Hat Development Suite', icns: path.resolve(__dirname + '/../../resources/devsuite.icns')});
   }
 
   static localAppData() {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -46,7 +46,7 @@ gulp.task('transpile:app', function() {
     .pipe(gulp.dest('transpiled'));
 
   var resources = gulp.src(['browser/**/*', '!browser/**/*.js', 'package.json',
-    'uninstaller/*', 'requirements.json', 'channels.json'], {base: '.'}
+    'uninstaller/*', 'requirements.json', 'channels.json', 'resources/*'], {base: '.'}
   ).pipe(gulp.dest('transpiled'));
 
   return merge(sources, resources);

--- a/test/unit/model/helpers/installer-test.js
+++ b/test/unit/model/helpers/installer-test.js
@@ -117,7 +117,7 @@ describe('Installer', function() {
       return installer.execElevated(command)
         .then(function() {
           expect(stub).to.have.been.calledOnce;
-          expect(stub).to.have.been.calledWith(command, {name: 'Red Hat Development Suite', icns: 'resources/devsuite.icns'});
+          expect(stub).to.have.been.calledWith(command, {name: 'Red Hat Development Suite', icns: path.resolve('./resources/devsuite.icns')});
         });
     });
 

--- a/test/unit/services/platform-test.js
+++ b/test/unit/services/platform-test.js
@@ -9,6 +9,7 @@ import mockfs from 'mock-fs';
 import fs from 'fs-extra';
 import sudo from 'sudo-prompt';
 import os from 'os';
+import path from 'path';
 chai.use(sinonChai);
 
 describe('Platform', function() {
@@ -623,7 +624,7 @@ describe('Platform', function() {
 
       it('sets the right name and icon for the sudo prompt', function() {
         return Platform.addToUserPath(executables).then(() => {
-          expect(sudo.exec).calledWith(sinon.match.any, {name: 'Red Hat Development Suite', icns: 'resources/devsuite.icns'});
+          expect(sudo.exec).calledWith(sinon.match.any, {name: 'Red Hat Development Suite', icns: path.resolve('./resources/devsuite.icns')});
         });
       });
     });


### PR DESCRIPTION
it turns out the icons needed by sudo prompt on mac were not packaged into the final archive and caused the prompt to fail miserably