### PR TITLE
Clean up install method

### DIFF
--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -227,21 +227,10 @@ class InstallableItem {
   }
 
   install(progress, success, failure) {
-    if( !this.getInstallAfter() || this.getInstallAfter().isInstalled() ) {
       progress.productName = this.productName;
       progress.productVersion = this.productVersion;
       progress.$timeout();
       this.installAfterRequirements(progress, success, failure);
-    } else {
-      this.ipcRenderer.on('installComplete', (event, arg) => {
-        if (!this.isInstalled() && arg === this.getInstallAfter().keyName) {
-          progress.productName = this.productName;
-          progress.productVersion = this.productVersion;
-          progress.$timeout();
-          this.installAfterRequirements(progress, success, failure);
-        }
-      });
-    }
   }
 
   installAfterRequirements(progress, success) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "devstudio-platform-installer",
-  "version": "2.2.0-GA",
+  "version": "2.3.0-GA",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4648,7 +4648,7 @@
       "dependencies": {
         "event-stream": {
           "version": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.5.tgz",
-          "integrity": "sha1-bLpaOuAqfkln1lrQTvElAqL/9mw=",
+          "integrity": "sha512-e0PL25oRBOrkyDgsasez9Qlze5xUElO1gq8tvARkyvgL7SiUrXgQNTNV5AGGtCwN9sCYQMMGIZRoKx1L7fauzg==",
           "dev": true,
           "requires": {
             "duplexer": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -4662,22 +4662,22 @@
           "dependencies": {
             "duplexer": {
               "version": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-              "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+              "integrity": "sha512-sxNZ+ljy+RA1maXoUReeqBBpBC6RLKmg5ewzV+x+mSETmWNoKdZN6vcQjpFROemza23hGFskJtFNoUWUaQ+R4Q==",
               "dev": true
             },
             "from": {
               "version": "http://registry.npmjs.org/from/-/from-0.1.3.tgz",
-              "integrity": "sha1-72OsIGKsMqz3hi4NQLRLiW8i87w=",
+              "integrity": "sha512-6vRx8eR96XRincv/5OIVNb5jxGRiaqQjdGq/VeDm4JvuwFH2gbpjFm0Afg8bqmFxTT1zP+4mNoG0k0C9+yvnEg==",
               "dev": true
             },
             "map-stream": {
               "version": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-              "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+              "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
               "dev": true
             },
             "pause-stream": {
               "version": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-              "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+              "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
               "dev": true,
               "requires": {
                 "through": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
@@ -4685,7 +4685,7 @@
             },
             "split": {
               "version": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-              "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+              "integrity": "sha512-e0pKq+UUH2Xq/sXbYpZBZc3BawsfDZ7dgv+JtRTUPNcvF5CMR4Y9cvJqkMY0MoxWzTHvZuz1beg6pNEKlszPiQ==",
               "dev": true,
               "requires": {
                 "through": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
@@ -4693,7 +4693,7 @@
             },
             "stream-combiner": {
               "version": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-              "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+              "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
               "dev": true,
               "requires": {
                 "duplexer": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
@@ -4701,14 +4701,14 @@
             },
             "through": {
               "version": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
-              "integrity": "sha1-JmgcD1JGcQIdTinffDa84tDs8ug=",
+              "integrity": "sha512-E8QCeJDd4xmHkGNnpBVZVgJxtziZg7T1dehN+QAD4pYy/D39FtmFu31qBtNc1aCwY2Y5++ZaGAd7Yf+NG/q1jw==",
               "dev": true
             }
           }
         },
         "gulp-util": {
           "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.1.tgz",
-          "integrity": "sha1-ghSJTQXCu2zH9VRJGKUd34gYDwA=",
+          "integrity": "sha512-z3IG6Tqjxy1CJnH6PxO57BgLQZoOUxThSTpsABOx4uc6D2ntOrvZJknlySQX+LyiE0CwjMfvoVRcDuK7iy1+9g==",
           "dev": true,
           "requires": {
             "chalk": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
@@ -4724,7 +4724,7 @@
           "dependencies": {
             "chalk": {
               "version": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-              "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+              "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
               "dev": true,
               "requires": {
                 "ansi-styles": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
@@ -4736,17 +4736,17 @@
               "dependencies": {
                 "ansi-styles": {
                   "version": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-                  "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+                  "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
                   "dev": true
                 },
                 "escape-string-regexp": {
                   "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-                  "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+                  "integrity": "sha512-cQpUid7bdTUnFin8S7BnNdOk+/eDqQmKgCANSyd/jAhrKEvxUvr9VQ8XZzXiOtest8NLfk3FSBZzwvemZNQ6Vg==",
                   "dev": true
                 },
                 "has-ansi": {
                   "version": "http://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                  "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                  "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
@@ -4754,14 +4754,14 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+                      "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
                       "dev": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                  "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                  "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
@@ -4769,21 +4769,21 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+                      "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
                       "dev": true
                     }
                   }
                 },
                 "supports-color": {
                   "version": "http://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-                  "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+                  "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
                   "dev": true
                 }
               }
             },
             "dateformat": {
               "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-              "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
+              "integrity": "sha512-5zcI+Qoul0QgiCcjzsobs9G1c+vHCNaYB2NGa57ZbVnP7bZeKJJgoM/K+I/obaHAmyEL0J8hJafbQ+HFSZnzZA==",
               "dev": true,
               "requires": {
                 "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
@@ -4792,12 +4792,12 @@
               "dependencies": {
                 "get-stdin": {
                   "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
-                  "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4=",
+                  "integrity": "sha512-jpAk+A3NUGL/O4N3pwG1Ld3PDqOxTkuAA/HoVHwutXsqW/qYcc4YSgccFpPlg/qbNhZ33ybFhJjbJqRZhryolQ==",
                   "dev": true
                 },
                 "meow": {
                   "version": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-                  "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
+                  "integrity": "sha512-X7rkdgy5Wxxp2MhCiAOkC3lqfkrJkt3iXvW4BY0rYQIn3GMvYvBTsAPEmHHTjTeVzBelrRcQa2F80rYfigz2+A==",
                   "dev": true,
                   "requires": {
                     "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
@@ -4808,7 +4808,7 @@
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
+                      "integrity": "sha512-hwNYKTjJTlDabjJp2xn0h8bRmOpObvXVgYbQmR+Xob/EeBDtYea3xttjr5hqiWqLWtI3/6xO7x1ZAktQ9up+ag==",
                       "dev": true,
                       "requires": {
                         "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
@@ -4817,19 +4817,19 @@
                       "dependencies": {
                         "camelcase": {
                           "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-                          "integrity": "sha1-eRLqwdSWg2eCyXbC1z6HTcVPLq8=",
+                          "integrity": "sha512-5jmcHpJIKH03K+TT918DJAfRWMclqFUCP+H8MGyRzVKu0S3qoiD9o1wOjat1ac5TdZQVBeXvGNxIcxZH86KvZw==",
                           "dev": true
                         },
                         "map-obj": {
                           "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
-                          "integrity": "sha1-vL32dWdYdjwYLa954YCUovHIV2Y=",
+                          "integrity": "sha512-88OHMGmqgI1PJyFq5T1DHORoxRWzb8cZmJaMdPUnt74tALy6/yA1BxMaiZpv17/oYZJ563520cz5IsoV06dE1A==",
                           "dev": true
                         }
                       }
                     },
                     "indent-string": {
                       "version": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.0.tgz",
-                      "integrity": "sha1-TXR3l9ZnRb1UxqKJ9c4Z9RdQpLk=",
+                      "integrity": "sha512-xx5+gz5UT8x1mFx1R+LB22Jc2/qrI2VFz/pIuUFZv9OFzeLKNsjCZUeNWwGxoBkSXemmEaVFXSBaJhv+PnKvag==",
                       "dev": true,
                       "requires": {
                         "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
@@ -4839,7 +4839,7 @@
                       "dependencies": {
                         "repeating": {
                           "version": "https://registry.npmjs.org/repeating/-/repeating-1.1.1.tgz",
-                          "integrity": "sha1-Lf5x+wuveCSejsalN+w91j9IuyI=",
+                          "integrity": "sha512-oEufnPNYzlx9DJgFJADuhB1dMoZHtrZJptVP+9gejpFz9jhgW5rzyoStd0s3WONx5yrJeJY1GZ37dpAvwWQnGw==",
                           "dev": true,
                           "requires": {
                             "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
@@ -4848,7 +4848,7 @@
                           "dependencies": {
                             "is-finite": {
                               "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
-                              "integrity": "sha1-Kx260RYs3Kak3InxKy89rhI5MoI=",
+                              "integrity": "sha512-FV+y987Wpk9kPnEWdqjBwQxYDJivAu61N0z/QGYrtSN0+QjWwiSdWILVuVir9Iljc3TAQvDxaTcEAqmVMY6pDQ==",
                               "dev": true
                             }
                           }
@@ -4857,7 +4857,7 @@
                     },
                     "object-assign": {
                       "version": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-                      "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY=",
+                      "integrity": "sha512-LpUkixU1BUMQ6bwUHbOue4IGGbdRbxi+IEZw7zHniw78erlxrKGHbhfLbHIsI35LGbGqys6QOrjVmLnD2ie+1A==",
                       "dev": true
                     }
                   }
@@ -4866,12 +4866,12 @@
             },
             "lodash._reinterpolate": {
               "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-              "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI=",
+              "integrity": "sha512-QGEOOjJi7W9LIgDAMVgtGBb8Qgo8ieDlSOCoZjtG45ZNRvDJZjwVMTYlfTIWdNRUiR1I9BjIqQ3Zaf1+DYM94g==",
               "dev": true
             },
             "lodash.template": {
               "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-              "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
+              "integrity": "sha512-5yLOQwlS69xbaez3g9dA1i0GMAj8pLDHp8lhA4V7M1vRam1lqD76f0jg5EV+65frbqrXo1WH9ZfKalfYBzJ5yQ==",
               "dev": true,
               "requires": {
                 "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
@@ -4885,12 +4885,12 @@
               "dependencies": {
                 "lodash._escapestringchar": {
                   "version": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-                  "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I=",
+                  "integrity": "sha512-iZ6Os4iipaE43pr9SBks+UpZgAjJgRC+lGf7onEoByMr1+Nagr1fmR7zCM6Q4RGMB/V3a57raEN0XZl7Uub3/g==",
                   "dev": true
                 },
                 "lodash.defaults": {
                   "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-                  "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
+                  "integrity": "sha512-5wTIPWwGGr07JFysAZB8+7JB2NjJKXDIwogSaRX5zED85zyUAQwtOqUk8AsJkkigUcL3akbHYXd5+BPtTGQPZw==",
                   "dev": true,
                   "requires": {
                     "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
@@ -4899,14 +4899,14 @@
                   "dependencies": {
                     "lodash._objecttypes": {
                       "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                      "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
                       "dev": true
                     }
                   }
                 },
                 "lodash.escape": {
                   "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-                  "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
+                  "integrity": "sha512-PiEStyvZ8gz37qBE+HqME1Yc/ewb/59AMOu8pG7Ztani86foPTxgzckQvMdphmXPY6V5f20Ex/CaNBqHG4/ycQ==",
                   "dev": true,
                   "requires": {
                     "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
@@ -4916,7 +4916,7 @@
                   "dependencies": {
                     "lodash._escapehtmlchar": {
                       "version": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-                      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
+                      "integrity": "sha512-eHm2t2Lg476lq5v4FVmm3B5mCaRlDyTE8fnMfPCEq2o46G4au0qNXIKh7YWhjprm1zgSMLcMSs1XHMgkw02PbQ==",
                       "dev": true,
                       "requires": {
                         "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
@@ -4924,14 +4924,14 @@
                       "dependencies": {
                         "lodash._htmlescapes": {
                           "version": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-                          "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
+                          "integrity": "sha512-g79hNmMOBVyV+4oKIHM7MWy9Awtk3yqf0Twlawr6f+CmG44nTwBh9I5XiLUnk39KTfYoDBpS66glQGgQCnFIuA==",
                           "dev": true
                         }
                       }
                     },
                     "lodash._reunescapedhtml": {
                       "version": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-                      "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
+                      "integrity": "sha512-CfmZRU1Mk4E/5jh+Wu8lc7tuc3VkuwWZYVIgdPDH9NRSHgiL4Or3AA4JCIpgrkVzHOM+jKu2OMkAVquruhRHDQ==",
                       "dev": true,
                       "requires": {
                         "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
@@ -4940,7 +4940,7 @@
                       "dependencies": {
                         "lodash._htmlescapes": {
                           "version": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-                          "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
+                          "integrity": "sha512-g79hNmMOBVyV+4oKIHM7MWy9Awtk3yqf0Twlawr6f+CmG44nTwBh9I5XiLUnk39KTfYoDBpS66glQGgQCnFIuA==",
                           "dev": true
                         }
                       }
@@ -4949,7 +4949,7 @@
                 },
                 "lodash.keys": {
                   "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                  "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+                  "integrity": "sha512-ZpJhwvUXHSNL5wYd1RM6CUa2ZuqorG9ngoJ9Ix5Cce+uX7I5O/E06FCJdhSZ33b5dVyeQDnIlWH7B2s5uByZ7g==",
                   "dev": true,
                   "requires": {
                     "lodash._isnative": "http://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
@@ -4959,12 +4959,12 @@
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "http://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-                      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                      "integrity": "sha512-BOlKGKNHhCHswGOWtmVb5zBygyxN7EmTuzVOSQI6QSoGhG+kvv71gICFS1TBpnqvT1n53txK8CDK3u5D2/GZxQ==",
                       "dev": true
                     },
                     "lodash._shimkeys": {
                       "version": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+                      "integrity": "sha512-lBrglYxLD/6KAJ8IEa5Lg+YHgNAL7FyKqXg4XOUI+Du/vtniLs1ZqS+yHNKPkK54waAgkdUnDOYaWf+rv4B+AA==",
                       "dev": true,
                       "requires": {
                         "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
@@ -4972,14 +4972,14 @@
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                          "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
                           "dev": true
                         }
                       }
                     },
                     "lodash.isobject": {
                       "version": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                      "integrity": "sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==",
                       "dev": true,
                       "requires": {
                         "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
@@ -4987,7 +4987,7 @@
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                          "integrity": "sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==",
                           "dev": true
                         }
                       }
@@ -4996,7 +4996,7 @@
                 },
                 "lodash.templatesettings": {
                   "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-                  "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
+                  "integrity": "sha512-vY3QQ7GxbeLe8XfTvoYDbaMHO5iyTDJS1KIZrxp00PRMmyBKr8yEcObHSl2ppYTwd8MgqPXAarTvLA14hx8ffw==",
                   "dev": true,
                   "requires": {
                     "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
@@ -5005,7 +5005,7 @@
                 },
                 "lodash.values": {
                   "version": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-                  "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
+                  "integrity": "sha512-fQwubKvj2Nox2gy6YnjFm8C1I6MIlzKUtBB+Pj7JGtloGqDDL5CPRr4DUUFWPwXWwAl2k3f4C3Aw8H1qAPB9ww==",
                   "dev": true,
                   "requires": {
                     "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
@@ -5015,12 +5015,12 @@
             },
             "minimist": {
               "version": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
-              "integrity": "sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM=",
+              "integrity": "sha512-ozllOyYiayzEgHCQKMPXKkOn9QRdeVe0TrIxLp+SJXMA0XNCL+yf4OtyPkB2JthzzYePYOTRnipBi3oOOa82sw==",
               "dev": true
             },
             "multipipe": {
               "version": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-              "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+              "integrity": "sha512-7ZxrUybYv9NonoXgwoOqtStIu18D1c3eFZj27hqgf5kBrBF8Q+tE8V0MW8dKM5QLkQPh1JhhbKgHLY9kifov4Q==",
               "dev": true,
               "requires": {
                 "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
@@ -5028,7 +5028,7 @@
               "dependencies": {
                 "duplexer2": {
                   "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+                  "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
                   "dev": true,
                   "requires": {
                     "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
@@ -5036,7 +5036,7 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                      "integrity": "sha512-E98tWzqShvKDGpR2MbjsDkDQWLW2TfWUC15H4tNQhIJ5Lsta84l8nUGL9/ybltGwe+wZzWPpc1Kmd2wQP4bdCA==",
                       "dev": true,
                       "requires": {
                         "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
@@ -5047,22 +5047,22 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                          "integrity": "sha512-fyj6blBb339ReZvm1g6NHGVI/q7THT6UJb1GVDMVxRvGb2v9J1xazqnfQ10wrChRH6tpxJLY/eUmFH0+gANIRA==",
                           "dev": true
                         },
                         "inherits": {
                           "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                          "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
                           "dev": true
                         },
                         "isarray": {
                           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
                           "dev": true
                         }
                       }
@@ -5073,7 +5073,7 @@
             },
             "vinyl": {
               "version": "http://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-              "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+              "integrity": "sha512-pmza4M5VA15HOImIQYWhoXGlGNafCm0QK5BpBUXkzzEwrRxKqBsbAhTfkT2zMcJhUX1G1Gkid0xaV8WjOl7DsA==",
               "dev": true,
               "requires": {
                 "clone": "http://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
@@ -5082,12 +5082,12 @@
               "dependencies": {
                 "clone": {
                   "version": "http://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                  "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                  "integrity": "sha512-g62n3Kb9cszeZvmvBUqP/dsEJD/+80pDA8u8KqHnAPrVnQ2Je9rVV6opxkhuWCd1kCn2gOibzDKxCtBvD3q5kA==",
                   "dev": true
                 },
                 "clone-stats": {
                   "version": "http://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+                  "integrity": "sha512-dhUqc57gSMCo6TX85FLfe51eC/s+Im2MLkAgJwfaRRexR2tA4dd3eLEW4L6efzHc2iNorrRRXITifnDLlRrhaA==",
                   "dev": true
                 }
               }
@@ -5096,12 +5096,12 @@
         },
         "lodash": {
           "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-          "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=",
+          "integrity": "sha512-qa6QqjA9jJB4AYw+NpD2GI4dzHL6Mv0hL+By6iIul4Ce0C1refrjZJmcGvWdnLUwl4LIPtvzje3UQfGH+nCEsQ==",
           "dev": true
         },
         "through2": {
           "version": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
-          "integrity": "sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=",
+          "integrity": "sha512-6UXIsO0fTTYMgxeQ9pisMOIqF/uL6Ebva+4HxihtLLR2gscWEu+OTMwar/0TYZaeDSNS1msIJAXJRis+GojL8g==",
           "dev": true,
           "requires": {
             "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
@@ -5110,7 +5110,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+              "integrity": "sha512-72KxhcKi8bAvHP/cyyWSP+ODS5ef0DIRs0OzrhGXw31q41f19aoELCbvd42FjhpyEDxQMRiiC5rq9rfE5PzTqg==",
               "dev": true,
               "requires": {
                 "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
@@ -5121,29 +5121,29 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                  "integrity": "sha512-fyj6blBb339ReZvm1g6NHGVI/q7THT6UJb1GVDMVxRvGb2v9J1xazqnfQ10wrChRH6tpxJLY/eUmFH0+gANIRA==",
                   "dev": true
                 },
                 "inherits": {
                   "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
                   "dev": true
                 },
                 "isarray": {
                   "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
                   "dev": true
                 }
               }
             },
             "xtend": {
               "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-              "integrity": "sha1-i8Nv+Hrtvnzp6vC8o2sjVKdDhA8=",
+              "integrity": "sha512-kRIX84vvgLbzkKD1wMkCxTtNwrBFfgXIzGuFKFBISJRDcMz4N8FBllDEndJkNl6HrFuQuzSbAEWpnuY/ydPVXg==",
               "dev": true
             }
           }
@@ -7660,6 +7660,24 @@
       "requires": {
         "is-promise": "1.0.1",
         "promise": "1.3.0"
+      }
+    },
+    "nomnom": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+      "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+      "dev": true,
+      "requires": {
+        "colors": "0.5.1",
+        "underscore": "1.4.4"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+          "dev": true
+        }
       }
     },
     "nopt": {
@@ -11681,6 +11699,41 @@
         "is-finite": "1.0.2"
       }
     },
+    "replace": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/replace/-/replace-0.3.0.tgz",
+      "integrity": "sha1-YAgXIRiGWFlatqeU63/ty0yNOcc=",
+      "dev": true,
+      "requires": {
+        "colors": "0.5.1",
+        "minimatch": "0.2.14",
+        "nomnom": "1.6.2"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
     "replace-ext": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
@@ -13750,6 +13803,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
       "integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
       "dev": true
     },
     "union-value": {

--- a/test/unit/model/installable-item-test.js
+++ b/test/unit/model/installable-item-test.js
@@ -55,7 +55,7 @@ describe('InstallableItem', function() {
 
   describe('install method', function() {
 
-    it('should call installAfterRequirements if required component is already installed', function() {
+    it('should call installAfterRequirements', function() {
       let svc = new InstallerDataService();
       let item1 = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', svc);
       let item2 = new InstallableItem('cygwin', 'url', 'installFile', 'targetFolderName', svc);
@@ -65,41 +65,6 @@ describe('InstallableItem', function() {
       item2.install(fakeProgress, sinon.stub(), sinon.stub());
       expect(item2.installAfterRequirements).to.be.calledOnce;
     });
-
-    it('should call installAfterRequirements after required component installed', function() {
-      let svc = new InstallerDataService();
-      let item1 = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', svc);
-      let item2 = new InstallableItem('cygwin', 'url', 'installFile', 'targetFolderName', svc);
-      item2.ipcRenderer = {
-        on: sinon.stub().yields(undefined, item1.keyName)
-      };
-      item2.installAfterRequirements = sinon.stub();
-      item1.isInstalled = sinon.stub().returns(false);
-      item1.thenInstall(item2);
-
-      item2.install(fakeProgress, sinon.stub(), sinon.stub());
-
-      expect(item2.installAfterRequirements).to.be.calledOnce;
-      expect(item2.ipcRenderer.on).to.be.calledOnce;
-    });
-
-    it('should not call installAfterRequirements for installComplete event about other none required components', function() {
-      let svc = new InstallerDataService();
-      let item1 = new InstallableItem('jdk', 'url', 'installFile', 'targetFolderName', svc);
-      let item2 = new InstallableItem('cygwin', 'url', 'installFile', 'targetFolderName', svc);
-      item2.ipcRenderer = {
-        on: sinon.stub().yields(undefined, 'devstudio')
-      };
-      item2.installAfterRequirements = sinon.stub();
-      item1.isInstalled = sinon.stub().returns(false);
-      item1.thenInstall(item2);
-
-      item2.install(fakeProgress, sinon.stub(), sinon.stub());
-
-      expect(item2.installAfterRequirements).not.to.be.called;
-      expect(item2.ipcRenderer.on).to.be.calledOnce;
-    });
-
   });
 
   describe('getInstallAfter method', function() {


### PR DESCRIPTION
Remove not needed code from install item install method.
Installation order now is based on flatten dependencies graph so
there is no reason to check if required components installed,
because required components are installed first.