### PR TITLE
Use 'direct' link to 7zip

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -649,7 +649,7 @@
       "win32": {
         "version": "9.20",
         "size": 384846,
-        "url": "http://www.7-zip.org/a/7za920.zip",
+        "url": "https://sourceforge.net/projects/sevenzip/files/7-Zip/9.20/7za920.zip/download?use_mirror=netcologne",
         "fileName": "7zip.zip",
         "sha256sum": "2a3afe19c180f8373fa02ff00254d5394fec0349f5804e0ad2f6067854ff28ac"
       }
@@ -664,7 +664,7 @@
       "win32": {
         "version": "9.20",
         "size": 520477,
-        "url": "http://www.7-zip.org/a/7z920_extra.7z",
+        "url": "https://sourceforge.net/projects/sevenzip/files/7-Zip/9.20/7z920_extra.7z/download?use_mirror=netcologne",
         "fileName": "7zip-extra.7z",
         "sha256sum": "d65a1d1a050e4fd7912c18468954f64db824a1e1b621235a153d010beae14757"
       }

--- a/test/check-requirements.js
+++ b/test/check-requirements.js
@@ -32,8 +32,8 @@ function checkRequirements() {
   fileNames['jbosseap'] = 'jboss-eap';
   fileNames['jdk'] = 'openjdk';
   fileNames['virtualbox'] = 'virtualbox';
-  fileNames['7zip'] = '7-zip';
-  fileNames['7zip-extra'] = '7-zip';
+  fileNames['7zip'] = '7-Zip';
+  fileNames['7zip-extra'] = '7-Zip';
   fileNames['kompose'] = 'kompose';
   fileNames['fuseplatformkaraf'] = 'karaf';
   fileNames['devstuidobpm'] = 'devstudio-integration-stack';


### PR DESCRIPTION
7zip is no longer hosting the files, everything is now on sourceforge. Trying to access the files directly instead of the redirect. Hopefully requirement check will be able to crunch it once more.