### PR TITLE
Guided development installer features implementation to fix #1289

### DIFF
--- a/browser/model/installable-item.js
+++ b/browser/model/installable-item.js
@@ -69,27 +69,27 @@ class InstallableItem {
     }
 
     this.downloaded = true;
-
-    for (let file in this.files) {
-      if (!fs.existsSync(path.join(this.bundleFolder, this.files[file].fileName))) {
-        if (fs.existsSync(path.join(this.downloadFolder, this.files[file].fileName))) {
-          try {
-            let stat = fs.statSync(path.join(this.downloadFolder, this.files[file].fileName));
-            this.files[file].downloaded = stat && stat.size == this.files[file].size;
-            this.downloaded = this.downloaded && this.files[file].downloaded;
-          } catch (error) {
+    if(this.useDownload) {
+      for (let file in this.files) {
+        if (!fs.existsSync(path.join(this.bundleFolder, this.files[file].fileName))) {
+          if (fs.existsSync(path.join(this.downloadFolder, this.files[file].fileName))) {
+            try {
+              let stat = fs.statSync(path.join(this.downloadFolder, this.files[file].fileName));
+              this.files[file].downloaded = stat && stat.size == this.files[file].size;
+              this.downloaded = this.downloaded && this.files[file].downloaded;
+            } catch (error) {
+              this.downloaded = false;
+              Logger.info(`${this.keyName} - fstat function failure ${error}`);
+            }
+          } else {
             this.downloaded = false;
-            Logger.info(`${this.keyName} - fstat function failure ${error}`);
           }
         } else {
-          this.downloaded = false;
+          this.files[file].downloaded = true;
+          this.downloadedFile = path.join(this.bundleFolder, this.files[file].fileName);
         }
-      } else {
-        this.files[file].downloaded = true;
-        this.downloadedFile = path.join(this.bundleFolder, this.files[file].fileName);
       }
     }
-
     this.installAfter = undefined;
     this.ipcRenderer = ipcRenderer;
     this.references = 0;

--- a/test/unit/model/guided-dev-test.js
+++ b/test/unit/model/guided-dev-test.js
@@ -52,7 +52,8 @@ describe('guided development installer', function() {
       sandbox.stub(Installer.prototype, 'unzip').resolves();
       sandbox.stub(Installer.prototype, 'exec').resolves();
       sandbox.stub(fs, 'rmdirSync').returns();
-      sandbox.stub(fs, 'mkdirSync').returns();
+      sandbox.stub(fs, 'ensureDirSync').returns();
+      sandbox.stub(fs, 'copySync').returns();
       sandbox.stub(Utils, 'writeFile').resolves(true);
       sandbox.stub(Utils, 'replaceInFile').resolves(true);
     });
@@ -80,8 +81,8 @@ describe('guided development installer', function() {
 
     it('should create "cheatsheets" folder in devstudio location if it is missing', function() {
       return guidedDevInstall.installAfterRequirements(fakeProgress, success, failure).then(()=> {
-        expect(fs.mkdirSync).to.have.been.calledOnce;
-        expect(fs.mkdirSync).to.have.been.calledWith(
+        expect(fs.ensureDirSync).to.have.been.calledOnce;
+        expect(fs.ensureDirSync).to.have.been.calledWith(
           path.join('install', 'devstudio', 'cheatsheets'));
       });
     });
@@ -89,7 +90,7 @@ describe('guided development installer', function() {
     it('should not create "cheatsheets" folder in devstudio location if it exists', function() {
       sandbox.stub(fs, 'existsSync').onFirstCall().returns(true).onSecondCall().returns(false);
       return guidedDevInstall.installAfterRequirements(fakeProgress, success, failure).then(()=> {
-        expect(fs.mkdirSync).not.called;
+        expect(fs.ensureDirSync).not.called;
       });
     });
 


### PR DESCRIPTION
1. Including cheatsheet xml into installer at build time and copy included cheatsheet to devstudio/cheasheets folder at installation time
2. Support cheatsheet generation with many cheatsheet references per guided development component