### PR TITLE
Fix mocha deprecation warning for --compilers parmeter

### DIFF
--- a/gulp-tasks/tests.js
+++ b/gulp-tasks/tests.js
@@ -19,7 +19,7 @@ module.exports = function(gulp) {
               read: false
             }).pipe(mocha({
               recursive: false,
-              compilers: 'js:babel-core/register',
+              require: 'babel-core/register',
               env: {
                 NODE_PATH: '.'
               },
@@ -38,7 +38,7 @@ module.exports = function(gulp) {
       read: false
     }).pipe(mocha({
       recursive: true,
-      compilers: 'js:babel-core/register',
+      require: 'babel-core/register',
       env: {
         NODE_PATH: '.'
       },


### PR DESCRIPTION
DeprecationWarning: "--compilers" will be removed in a future version of
Mocha; see https://git.io/vdcSr for more info