### PR TITLE
Update Group Name when no DevStudio and CDK installed

### DIFF
--- a/browser/pages/start/start.html
+++ b/browser/pages/start/start.html
@@ -17,10 +17,19 @@
             <div class="card-pf-body" style="min-height: 100px; overflow: hidden;">
               <section class="product-header">
                 <div class="row">
-                  <div class="header-column"> 
-                    <h2>
-                      <span class="field-name-title">Miscellaneous Components</span>
-                    </h2> 
+                  <div class="header-column">
+                    <h2 ng-hide="!startCtrl.devstudioInstall.installed && !startCtrl.cdkInstall.installed">
+                      <span class="field-name-title">Miscellaneous Installed Components</span>
+                    </h2>
+                    <div ng-hide="!startCtrl.devstudioInstall.installed && !startCtrl.cdkInstall.installed">
+                      The list of other installed components
+                    </div>
+                    <h2 ng-hide="startCtrl.devstudioInstall.installed || startCtrl.cdkInstall.installed">
+                      <span class="field-name-title">Installed Components</span>
+                    </h2>
+                    <div ng-hide="startCtrl.devstudioInstall.installed || startCtrl.cdkInstall.installed">
+                      The list of installed components
+                    </div>
                   </div>
                 </div>
               </section>


### PR DESCRIPTION
Fix removes 'Miscellaneous' from title of the group dedicated
to show comonents installed that are not related to cdk
or devstudio. It also removes 'other' from group's description.