### PR TITLE
Allow Java 9+ to be detected

### DIFF
--- a/browser/directives/componentPanel.html
+++ b/browser/directives/componentPanel.html
@@ -49,7 +49,7 @@
     <span>You have selected
       <ng-repeat ng-repeat="dep in filtered = (item.dependenciesOf | filter: {selectedOption: 'install'} | limitTo:1)">
         <span>{{dep.productName}},</span>
-      </ng-repeat> which requires {{item.productName}} version {{item.minimumVersion}} or higher.</span>
+      </ng-repeat> which requires {{item.productName}} version {{item.minimumVersion}}{{item.orHigher}}.</span>
       <span ng-show="item.messages.dependency !== undefined">
         <span>{{item.messages.dependency.message.split(item.messages.dependency.linkDescription)[0]}}</span>
         <a type="button" class="pointer" ng-click="openUrl(item.messages.dependency.link ? item.messages.dependency.link : item.downloadUrl)">

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -2,7 +2,8 @@
 
 let fs = require('fs-extra');
 let path = require('path');
-var rimraf = require('rimraf');
+let rimraf = require('rimraf');
+let semver = require('semver');
 
 
 import InstallableItem from './installable-item';
@@ -35,7 +36,7 @@ class JdkInstall extends InstallableItem {
   }
 
   detectExistingInstall() {
-    let versionRegex = /version\s"(\d+\.\d+\.\d+).*"/;
+    let versionRegex = /version\s"(.+)".*/;
     let versionRegex1 = /(\d+\.\d+\.\d+).*/;
     let command = 'java -XshowSettings';
     this.addOption('install', versionRegex1.exec(this.version)[1], this.installerDataSvc.jdkDir(), true);
@@ -53,15 +54,11 @@ class JdkInstall extends InstallableItem {
     }).then((output) => {
       return new Promise((resolve, reject) => {
         let version = versionRegex.exec(output);
-        if (version && version.length > 1) {
+        if (version && version.length > 1 && version[1].length > 0) {
           this.addOption('detected', version[1], '', true);
-          this.option['detected'].version = version[1];
           this.selectedOption = 'detected';
           this.validateVersion();
-          if(this.option['detected'].valid) {
-            this.selectedOption = 'detected';
-          }
-          resolve(true);
+          resolve();
         } else {
           reject('No java detected');
         }
@@ -111,14 +108,15 @@ class JdkInstall extends InstallableItem {
   validateVersion() {
     let option = this.option[this.selectedOption];
     if(option) {
+      let v = semver.coerce(option.version);
       option.valid = true;
       option.error = '';
       option.warning = '';
-      if(Version.LT(option.version, this.minimumVersion)) {
+      if(Version.LT(v, this.minimumVersion)) {
         option.valid = false;
         option.error = 'oldVersion';
         option.warning = '';
-      } else if(Version.GT(option.version, this.minimumVersion)) {
+      } else if(Version.GT(v, this.minimumVersion)) {
         option.valid = false;
         option.error = '';
         option.warning = 'newerVersion';

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -20,6 +20,7 @@ class JdkInstall extends InstallableItem {
     this.sha256 = sha256sum;
     this.minimumVersion = '1.8.0';
     this.openJdkMsi = false;
+    this.orHigher = '';
   }
 
   static get KEY() {
@@ -34,7 +35,7 @@ class JdkInstall extends InstallableItem {
   }
 
   detectExistingInstall() {
-    let versionRegex = /version\s"(\d+\.\d+\.\d+)_.*"/;
+    let versionRegex = /version\s"(\d+\.\d+\.\d+).*"/;
     let versionRegex1 = /(\d+\.\d+\.\d+).*/;
     let command = 'java -XshowSettings';
     this.addOption('install', versionRegex1.exec(this.version)[1], this.installerDataSvc.jdkDir(), true);

--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -119,7 +119,7 @@ class JdkInstall extends InstallableItem {
         option.error = 'oldVersion';
         option.warning = '';
       } else if(Version.GT(option.version, this.minimumVersion)) {
-        option.valid = true;
+        option.valid = false;
         option.error = '';
         option.warning = 'newerVersion';
       }

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -16,7 +16,8 @@ class VirtualBoxInstall extends InstallableItem {
 
     this.minimumVersion = '5.1.12';
     this.revision = revision;
-
+    this.orHigher = ' or higher';
+    
     this.downloadUrl = this.downloadUrl.split('${version}').join(this.version);
     this.downloadUrl = this.downloadUrl.split('${revision}').join(this.revision);
 

--- a/browser/model/virtualbox.js
+++ b/browser/model/virtualbox.js
@@ -15,9 +15,9 @@ class VirtualBoxInstall extends InstallableItem {
     super(VirtualBoxInstall.KEY, downloadUrl, fileName, targetFolderName, installerDataSvc, false);
 
     this.minimumVersion = '5.1.12';
-    this.revision = revision;
     this.orHigher = ' or higher';
-    
+    this.revision = revision;
+
     this.downloadUrl = this.downloadUrl.split('${version}').join(this.version);
     this.downloadUrl = this.downloadUrl.split('${revision}').join(this.revision);
 

--- a/test/unit/model/jdk-install-test.js
+++ b/test/unit/model/jdk-install-test.js
@@ -168,7 +168,7 @@ describe('JDK installer', function() {
       });
 
       it('should reject openjdk if location for java is not found', function() {
-        mockDetectedJvm('1.8.0', '');
+        mockDetectedJvm('', '');
         return jdk.detectExistingInstall().then(()=> {
           expect(jdk.selectedOption).to.be.equal('install');
         });


### PR DESCRIPTION
Fix #1336 and at least show message that Java 1.8.0 is required.