### PR TITLE
Select Open JDK 8 to install if required and Java 9+ detected

### DIFF
--- a/browser/model/jdk-install.js
+++ b/browser/model/jdk-install.js
@@ -86,7 +86,7 @@ class JdkInstall extends InstallableItem {
   }
 
   getMsiSearchScriptData() {
-    return 'REG QUERY HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall /f "OpenJDK" /s';
+    return 'REG QUERY HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall /f "OpenJDK 1.8.0" /s';
   }
 
   findMsiInstalledJava() {
@@ -176,7 +176,7 @@ class JdkInstall extends InstallableItem {
 
   isDisabled() {
     return !this.hasOption('detected') && (this.references > 0)
-    || this.hasOption('detected') && !this.option.detected.valid
+    || this.hasOption('detected') && !this.option.detected.valid && (this.references > 0)
     || this.hasOption('detected') && this.option.detected.valid && this.openJdkMsi
     || Platform.OS === 'darwin';
   }

--- a/browser/pages/selection/controller.js
+++ b/browser/pages/selection/controller.js
@@ -129,7 +129,10 @@ class SelectionController {
     if(installer.isSelected()) {
       for(let dep of graph.dependenciesOf(node)) {
         let depInstaller = checkboxModel[dep];
-        if(depInstaller.isInstallable && depInstaller.references === 0 && depInstaller.isNotDetected()) {
+        if(depInstaller.isInstallable
+          && !depInstaller.isDisabled()
+          && depInstaller.references === 0
+          && (depInstaller.isNotDetected() || depInstaller.isInvalidVersionDetected())) {
           depInstaller.selectedOption = 'install';
         }
         depInstaller.references++;


### PR DESCRIPTION
requires https://github.com/redhat-developer-tooling/developer-platform-install/pull/1384 and https://github.com/redhat-developer-tooling/developer-platform-install/pull/1385 to work.