### PR TITLE
update cdk hello-world page without hash link

### DIFF
--- a/browser/pages/start/controller.js
+++ b/browser/pages/start/controller.js
@@ -20,7 +20,7 @@ class StartController {
   }
   
   static get START_CDK_URL () {
-    return 'https://developers.redhat.com/products/cdk/hello-world/#cdk_build-your-first-app';
+    return 'https://developers.redhat.com/products/cdk/hello-world/';
   }
 
   fetchMiscComponents() {


### PR DESCRIPTION
As there is no update on the redesign timeframe, the permanent links for hello-world are not yet updated. So rolling back to the url which won't break in the future till the new design is up.

Relates to  #1132 