### PR TITLE
Fix 'clear all' deselecting components while dependents are still selected

### DIFF
--- a/browser/pages/selection/controller.js
+++ b/browser/pages/selection/controller.js
@@ -52,6 +52,7 @@ class SelectionController {
   }
 
   toggleSelection(type) {
+    let deselectedComponents = [];
     this.componentsInChannel(this.channel_tab).forEach((node)=>{
       if(type==='all') {
         if (node.isInstallable && node.isNotDetected()) {
@@ -59,8 +60,14 @@ class SelectionController {
         }
       } else if(type==='none') {
         node.selectedOption = 'detected';
+        deselectedComponents.push(node);
       }
     });
+    for (const node of deselectedComponents) {
+      if (node.references > 0) {
+        node.selectedOption = 'install';
+      }
+    }
   }
 
   channelBadge(tab) {


### PR DESCRIPTION
Turns out one can select a component with its dependencies in one channel, then switch to a different channel and use 'clear all' to simply deselect the dependencies without the original item. 

Example: select Java Development in Guided Development channel -> go to Java Development channel -> click Clear All -> everything in Java Dev channel gets deselected even though Guided Development is still selected

This PR should check if the deselected component still has something depending on it before committing. 