### PR TITLE
Look for xhyve in /usr/local/bin

### DIFF
--- a/browser/services/platform.js
+++ b/browser/services/platform.js
@@ -144,7 +144,9 @@ class Platform {
   static isXhyveAvailable() {
     return Platform.identify({
       darwin: ()=> {
-        return pify(child_process.exec)('which docker-machine-driver-xhyve').then((stdout) => {
+        let newPath = `/usr/local/bin${path.delimiter}${process.env.PATH}`;
+
+        return pify(child_process.exec)('which docker-machine-driver-xhyve', {env: {PATH: newPath}}).then((stdout) => {
           return Promise.resolve(stdout.trim().length > 0);
         }).catch(() => { 
           return Promise.resolve(false);


### PR DESCRIPTION
when run from dmg, the installer has its PATH limited to `/usr/bin:/bin:/usr/sbin:/sbin`
no idea why, but since xhyve is usually in `/usr/local/bin` we should look there as well